### PR TITLE
Copy Paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   * [NBT Changer](#nbt-changer)
   * [Chunk Editor](#chunk-editor)
   * [Chunk import](#chunk-import)
+  * [Copy and Paste](#copy-and-paste)
   * [Swapping chunks](#swapping-chunks)
   * [Caching](#caching)
   * [Debugging](#debugging)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ Options:
 Commands inside of command blocks will not be changed.
 Maps will not be updated, because their data is not stored inside region files.
 
+### Copy-Paste
+It is possible to copy a selection to the system clipboard and pasting it to a different location in the same world or into an entirely different world.
+After making a selection, use `Selection --> Copy chunks` or press `Ctrl+C` (`Cmd+C` on Mac). After navigating to the location in the world where the copied chunks need to be pasted, use `Selection --> Paste chunks` or press `Ctrl+V` (`Cmd+V`on Mac) to display an overlay showing where the clipboard will be imported to. The overlay can be moved around by pressing and holding the left mouse button. Press `Ctrl+V` again to import the chunks at the selected location. This will open the [Import chunks](#chunk-import) dialog with prefilled values depending on where the overlay has been placed.
+Copying can be cancelled by pressing `Esc`.
+
 ### Swapping chunks
 When exactly two chunks are selected, they can be swapped using `Tools --> Swap chunks`. This is useful for corrupted region files when Minecraft failed to correctly save the region file index, resulting in scrambled chunks.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 #### An external tool to export or delete selected chunks and regions from a world save of Minecraft Java Edition.
 ---
 
-**Update 1.11 adds new features that can be useful when migrating a world to 1.16. [Here](https://gist.github.com/Querz/008111195cc7bc012bb291849d2eb9c7) is a document with some tips and tricks regarding 1.16.**
+**Update 1.11 added new features that can be useful when migrating a world to 1.16. [Here](https://gist.github.com/Querz/008111195cc7bc012bb291849d2eb9c7) is a document with some tips and tricks regarding 1.16.**
 
 ---
 
@@ -317,7 +317,7 @@ If you would like to contribute a translation, you can find the language files i
 
 ## Download and installation
 
-[**Download Version 1.11.1**](https://github.com/Querz/mcaselector/releases/download/1.11.1/mcaselector-1.11.1.jar)
+[**Download Version 1.12**](https://github.com/Querz/mcaselector/releases/download/1.12/mcaselector-1.12.jar)
 
 "Requirements":
 * Either:
@@ -328,11 +328,11 @@ If you would like to contribute a translation, you can find the language files i
 
 #### If you have Java from Oracle installed on your system
 
-Most likely, `.jar` files are associated with java on your computer, it should therefore launch by simply double clicking the file (or however your OS is configured to open files using your mouse or keyboard). If not, you can try `java -jar mcaselector-1.11.1.jar` from your console. If this doesn't work, you might want to look into how to modify the `PATH` variable on your system to tell your system that java is an executable program.
+Most likely, `.jar` files are associated with java on your computer, it should therefore launch by simply double clicking the file (or however your OS is configured to open files using your mouse or keyboard). If not, you can try `java -jar mcaselector-1.12.jar` from your console. If this doesn't work, you might want to look into how to modify the `PATH` variable on your system to tell your system that java is an executable program.
 
 #### If you have Minecraft Java Edition installed on your system
 
-Minecraft Java Edition comes with a JRE that you can use to start the MCA Selector, so there is no need to install another version of java on your system. On Windows, that java version is usually located in `C:\Program Files (x86)\Minecraft\runtime\jre-x64\bin\` and once inside this folder you can simply run `java.exe -jar <path-to-mcaselector-1.11.1.jar>`. On Mac OS you should find it in `~/Library/Application\ Support/minecraft/runtime/jre-x64/jre.bundle/Contents/Home/bin/` where you can execute `./java -jar <path-to-mcaselector-1.11.1.jar>`.
+Minecraft Java Edition comes with a JRE that you can use to start the MCA Selector, so there is no need to install another version of java on your system. On Windows, that java version is usually located in `C:\Program Files (x86)\Minecraft\runtime\jre-x64\bin\` and once inside this folder you can simply run `java.exe -jar <path-to-mcaselector-1.12.jar>`. On Mac OS you should find it in `~/Library/Application\ Support/minecraft/runtime/jre-x64/jre.bundle/Contents/Home/bin/` where you can execute `./java -jar <path-to-mcaselector-1.12.jar>`.
 
 **WARNING:** For macOS 10.14+ (Mojave) It is NOT recommended to use the JRE provided by Minecraft (1.8.0_74), because it contains a severe bug that causes JavaFX applications to crash when they lose focus while a dialog window (such as the save-file-dialog) is open (see the bug report [here](https://bugs.openjdk.java.net/browse/JDK-8211304)). This bug has been fixed in Java 1.8.0_201 and above.
 
@@ -346,12 +346,12 @@ If you are using Java 11 or higher, the JavaFX modules are not included automati
 
 On Windows with Oracle Java 13:
 ```
-"C:\Program Files\Java\jdk-13.0.1\bin\java.exe" --module-path "C:\Program Files\Java\javafx-sdk-13.0.1\lib" --add-modules ALL-MODULE-PATH -jar mcaselector-1.11.1.jar
+"C:\Program Files\Java\jdk-13.0.1\bin\java.exe" --module-path "C:\Program Files\Java\javafx-sdk-13.0.1\lib" --add-modules ALL-MODULE-PATH -jar mcaselector-1.12.jar
 ```
 
 On Debian with OpenJDK 11 and openjfx:
 ```
-java --module-path /usr/share/openjfx/lib --add-modules ALL-MODULE-PATH -jar mcaselector-1.11.1.jar
+java --module-path /usr/share/openjfx/lib --add-modules ALL-MODULE-PATH -jar mcaselector-1.12.jar
 ```
 
 ##

--- a/README.md
+++ b/README.md
@@ -332,9 +332,10 @@ If you would like to contribute a translation, you can find the language files i
 
 "Requirements":
 * Either:
-  * JRE 8+, you can get it from [HERE](https://www.java.com/en/download/windows-64bit.jsp)
+  * 64bit JRE 8+, you can get it from [HERE](https://www.java.com/en/download/windows-64bit.jsp)
   * A Minecraft Java Edition installation
 * A computer
+  * At least 6 GB of RAM. If lower, more RAM has to manually be assigned to the JVM using the `-Xmx` argument. Assigning 4 GB is recommended.
 * A brain
 
 #### If you have Java from Oracle installed on your system

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Zooming out far enough disables the selection of single chunks but lets you sele
 Upon finishing selecting chunks and regions, they can be deleted or exported using the `Selection`-menu. Exported chunks and regions are not deleted from the original world.
 
 <p align="center">
-  <img src="https://gist.githubusercontent.com/Querz/5e08c4ab863c2ad8b5da146dc4188ecb/raw/306b90aa139a9c029705570393178266d7117b6b/selections.png" alt="MCA Selector window showing chunk and region selection export">
+  <img src="https://gist.githubusercontent.com/Querz/5e08c4ab863c2ad8b5da146dc4188ecb/raw/f17333764e8b3ab281c707587db7c73b23b589b1/selections.png" alt="MCA Selector window showing chunk and region selection export">
 </p>
 
 A selection (not the chunks and regions themselves) can also be exported or imported and even be applied to different worlds.
@@ -152,10 +152,14 @@ Options:
 Commands inside of command blocks will not be changed.
 Maps will not be updated, because their data is not stored inside region files.
 
-### Copy-Paste
+### Copy and Paste
 It is possible to copy a selection to the system clipboard and pasting it to a different location in the same world or into an entirely different world.
 After making a selection, use `Selection --> Copy chunks` or press `Ctrl+C` (`Cmd+C` on Mac). After navigating to the location in the world where the copied chunks need to be pasted, use `Selection --> Paste chunks` or press `Ctrl+V` (`Cmd+V`on Mac) to display an overlay showing where the clipboard will be imported to. The overlay can be moved around by pressing and holding the left mouse button. Press `Ctrl+V` again to import the chunks at the selected location. This will open the [Import chunks](#chunk-import) dialog with prefilled values depending on where the overlay has been placed.
 Copying can be cancelled by pressing `Esc`.
+
+<p align="center">
+  <img src="https://gist.githubusercontent.com/Querz/5e08c4ab863c2ad8b5da146dc4188ecb/raw/f17333764e8b3ab281c707587db7c73b23b589b1/copy_paste.png" alt="MCA Selector window showing copy-paste overlay">
+</p>
 
 ### Swapping chunks
 When exactly two chunks are selected, they can be swapped using `Tools --> Swap chunks`. This is useful for corrupted region files when Minecraft failed to correctly save the region file index, resulting in scrambled chunks.

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'idea'
 apply plugin: 'css'
 
 group 'net.querz.mcaselector'
-version '1.11.1'
+version '1.12'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -37,9 +37,9 @@ public final class Config {
 	public static final Color DEFAULT_PASTE_CHUNKS_COLOR = new Color(0, 1, 0, 0.8);
 	public static final Locale DEFAULT_LOCALE = Locale.UK;
 	public static final int DEFAULT_LOAD_THREADS = 1;
-	public static final int DEFAULT_PROCESS_THREADS = Runtime.getRuntime().availableProcessors();
-	public static final int DEFAULT_WRITE_THREADS = 4;
-	public static final int DEFAULT_MAX_LOADED_FILES = DEFAULT_PROCESS_THREADS + (DEFAULT_PROCESS_THREADS / 2);
+	public static final int DEFAULT_PROCESS_THREADS = Math.max(Runtime.getRuntime().availableProcessors() - 2, 1);
+	public static final int DEFAULT_WRITE_THREADS = Math.min(Runtime.getRuntime().availableProcessors(), 4);
+	public static final int DEFAULT_MAX_LOADED_FILES = (int) Math.max(Math.ceil(Runtime.getRuntime().maxMemory() / 1_000_000_000D) * 2, 1);
 	public static final boolean DEFAULT_SHADE = true;
 	public static final boolean DEFAULT_SHADE_WATER = true;
 	public static final boolean DEFAULT_DEBUG = false;

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -32,7 +32,7 @@ public final class Config {
 
 	public static final File DEFAULT_BASE_CACHE_DIR = new File(DEFAULT_BASE_DIR, "cache");
 
-	public static final Color DEFAULT_REGION_SELECTION_COLOR = new Color(1, 0, 0, 0.8);
+	public static final Color DEFAULT_REGION_SELECTION_COLOR = new Color(1, 0.45, 0, 0.8);
 	public static final Color DEFAULT_CHUNK_SELECTION_COLOR = new Color(1, 0.45, 0, 0.8);
 	public static final Color DEFAULT_PASTE_CHUNKS_COLOR = new Color(0, 1, 0, 0.8);
 	public static final Locale DEFAULT_LOCALE = Locale.UK;
@@ -189,6 +189,7 @@ public final class Config {
 
 			regionSelectionColor = new Color(config.getOrDefault("RegionSelectionColor", DEFAULT_REGION_SELECTION_COLOR.toString()));
 			chunkSelectionColor = new Color(config.getOrDefault("ChunkSelectionColor", DEFAULT_CHUNK_SELECTION_COLOR.toString()));
+			pasteChunksColor = new Color(config.getOrDefault("PasteChunksColor", DEFAULT_PASTE_CHUNKS_COLOR.toString()));
 			loadThreads = Integer.parseInt(config.getOrDefault("LoadThreads", DEFAULT_LOAD_THREADS + ""));
 			processThreads = Integer.parseInt(config.getOrDefault("ProcessThreads", DEFAULT_PROCESS_THREADS + ""));
 			writeThreads = Integer.parseInt(config.getOrDefault("WriteThreads", DEFAULT_WRITE_THREADS + ""));
@@ -212,6 +213,7 @@ public final class Config {
 		addSettingsLine("Locale", locale.toString(), DEFAULT_LOCALE.toString(), lines);
 		addSettingsLine("RegionSelectionColor", regionSelectionColor.toString(), DEFAULT_REGION_SELECTION_COLOR.toString(), lines);
 		addSettingsLine("ChunkSelectionColor", chunkSelectionColor.toString(), DEFAULT_CHUNK_SELECTION_COLOR.toString(), lines);
+		addSettingsLine("PasteChunksColor", pasteChunksColor.toString(), DEFAULT_PASTE_CHUNKS_COLOR.toString(), lines);
 		addSettingsLine("LoadThreads", loadThreads, DEFAULT_LOAD_THREADS, lines);
 		addSettingsLine("ProcessThreads", processThreads, DEFAULT_PROCESS_THREADS, lines);
 		addSettingsLine("WriteThreads", writeThreads, DEFAULT_WRITE_THREADS, lines);

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -34,6 +34,7 @@ public final class Config {
 
 	public static final Color DEFAULT_REGION_SELECTION_COLOR = new Color(1, 0, 0, 0.8);
 	public static final Color DEFAULT_CHUNK_SELECTION_COLOR = new Color(1, 0.45, 0, 0.8);
+	public static final Color DEFAULT_PASTE_CHUNKS_COLOR = new Color(0, 1, 0, 0.8);
 	public static final Locale DEFAULT_LOCALE = Locale.UK;
 	public static final int DEFAULT_LOAD_THREADS = 1;
 	public static final int DEFAULT_PROCESS_THREADS = Runtime.getRuntime().availableProcessors();
@@ -51,6 +52,7 @@ public final class Config {
 	private static Locale locale = DEFAULT_LOCALE;
 	private static Color regionSelectionColor = DEFAULT_REGION_SELECTION_COLOR;
 	private static Color chunkSelectionColor = DEFAULT_CHUNK_SELECTION_COLOR;
+	private static Color pasteChunksColor = DEFAULT_PASTE_CHUNKS_COLOR;
 	private static int loadThreads = DEFAULT_LOAD_THREADS;
 	private static int processThreads = DEFAULT_PROCESS_THREADS;
 	private static int writeThreads = DEFAULT_WRITE_THREADS;
@@ -242,6 +244,14 @@ public final class Config {
 
 	public static void setChunkSelectionColor(Color chunkSelectionColor) {
 		Config.chunkSelectionColor = chunkSelectionColor;
+	}
+
+	public static Color getPasteChunksColor() {
+		return pasteChunksColor;
+	}
+
+	public static void setPasteChunksColor(Color pasteChunksColor) {
+		Config.pasteChunksColor = pasteChunksColor;
 	}
 
 	public static int getLoadThreads() {

--- a/src/main/java/net/querz/mcaselector/Main.java
+++ b/src/main/java/net/querz/mcaselector/Main.java
@@ -1,9 +1,11 @@
 package net.querz.mcaselector;
 
+import net.querz.mcaselector.headless.HeadlessHelper;
 import net.querz.mcaselector.headless.ParamExecutor;
 import net.querz.mcaselector.ui.Window;
 import net.querz.mcaselector.debug.Debug;
 import net.querz.mcaselector.text.Translation;
+import javax.swing.*;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -18,6 +20,11 @@ public class Main {
 		if (headless != null && headless.get()) {
 			// we already ran headless mode, so we exit here
 			Debug.print("exiting");
+			System.exit(0);
+		}
+
+		if (!HeadlessHelper.hasJavaFX()) {
+			JOptionPane.showMessageDialog(null, "Please install JavaFX for your Java version (" + System.getProperty("java.version") + ") to use MCA Selector.", "Missing JavaFX", JOptionPane.ERROR_MESSAGE);
 			System.exit(0);
 		}
 

--- a/src/main/java/net/querz/mcaselector/debug/Debug.java
+++ b/src/main/java/net/querz/mcaselector/debug/Debug.java
@@ -1,12 +1,11 @@
 package net.querz.mcaselector.debug;
 
 import net.querz.mcaselector.Config;
+import net.querz.mcaselector.text.TextHelper;
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -27,7 +26,7 @@ public final class Debug {
 					if (!lastExceptions.containsKey(info)) {
 						lastExceptions.put(info, info);
 						if (logWriter != null) {
-							appendLogFile(getStacktraceAsString((Exception) o));
+							appendLogFile(TextHelper.getStacktraceAsString((Exception) o));
 						}
 						((Exception) o).printStackTrace();
 					} else {
@@ -60,7 +59,7 @@ public final class Debug {
 				if (!lastExceptions.containsKey(info)) {
 					lastExceptions.put(info, info);
 					if (logWriter != null) {
-						appendLogFile(getStacktraceAsString((Exception) o));
+						appendLogFile(TextHelper.getStacktraceAsString((Exception) o));
 					}
 					((Exception) o).printStackTrace();
 				} else {
@@ -213,14 +212,6 @@ public final class Debug {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-	}
-
-	private static String getStacktraceAsString(Exception ex) {
-		StringWriter sw = new StringWriter();
-		PrintWriter pw = new PrintWriter(sw);
-		ex.printStackTrace(pw);
-		pw.flush();
-		return sw.toString();
 	}
 
 	private static String getExceptionOneLine(Exception ex) {

--- a/src/main/java/net/querz/mcaselector/headless/HeadlessHelper.java
+++ b/src/main/java/net/querz/mcaselector/headless/HeadlessHelper.java
@@ -1,0 +1,15 @@
+package net.querz.mcaselector.headless;
+
+public final class HeadlessHelper {
+
+	private HeadlessHelper() {}
+
+	public static boolean hasJavaFX() {
+		try  {
+			Class.forName("javafx.scene.paint.Color");
+			return true;
+		}  catch (ClassNotFoundException e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
@@ -230,7 +230,11 @@ public class ParamExecutor {
 		progress.onDone(future);
 
 		// TODO: add support for source chunk selection
-		ChunkImporter.importChunks(input, progress, true, overwrite, null, selection, ranges, new Point2i(offsetX, offsetZ));
+		DataProperty<File> actualImportDir = new DataProperty<>();
+		ChunkImporter.importChunks(input, progress, true, overwrite, null, selection, ranges, new Point2i(offsetX, offsetZ), actualImportDir);
+		if (actualImportDir.get() != input) {
+			FileHelper.clearFolder(actualImportDir.get());
+		}
 	}
 
 	private static void runModeExport(Map<String, String> params, FutureTask<Boolean> future) throws IOException {

--- a/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
@@ -229,11 +229,14 @@ public class ParamExecutor {
 		ConsoleProgress progress = new ConsoleProgress();
 		progress.onDone(future);
 
-		// TODO: add support for source chunk selection
-		DataProperty<File> actualImportDir = new DataProperty<>();
-		ChunkImporter.importChunks(input, progress, true, overwrite, null, selection, ranges, new Point2i(offsetX, offsetZ), actualImportDir);
-		if (actualImportDir.get() != input) {
-			FileHelper.clearFolder(actualImportDir.get());
+		DataProperty<Map<Point2i, File>> tempFiles = new DataProperty<>();
+		ChunkImporter.importChunks(input, progress, true, overwrite, null, selection, ranges, new Point2i(offsetX, offsetZ), tempFiles);
+		if (tempFiles.get() != null) {
+			for (File tempFile : tempFiles.get().values()) {
+				if (!tempFile.delete()) {
+					Debug.errorf("failed to delete temp file %s", tempFile);
+				}
+			}
 		}
 	}
 

--- a/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
@@ -229,7 +229,8 @@ public class ParamExecutor {
 		ConsoleProgress progress = new ConsoleProgress();
 		progress.onDone(future);
 
-		ChunkImporter.importChunks(input, progress, true, overwrite, selection, ranges, new Point2i(offsetX, offsetZ));
+		// TODO: add support for source chunk selection
+		ChunkImporter.importChunks(input, progress, true, overwrite, null, selection, ranges, new Point2i(offsetX, offsetZ));
 	}
 
 	private static void runModeExport(Map<String, String> params, FutureTask<Boolean> future) throws IOException {

--- a/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
@@ -124,7 +124,7 @@ public class ParamExecutor {
 	}
 
 	private static void runModeCache(Map<String, String> params, FutureTask<Boolean> future) throws IOException {
-		if (!hasJavaFX()) {
+		if (!HeadlessHelper.hasJavaFX()) {
 			throw new IOException("no JavaFX installation found");
 		}
 
@@ -391,15 +391,6 @@ public class ParamExecutor {
 	private static void createParentDirectoryIfNotExists(File file) throws IOException {
 		if (file.getParentFile() != null && !file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
 			throw new IOException("unable to create directory for \"" + file + "\"");
-		}
-	}
-
-	private static boolean hasJavaFX() {
-		try  {
-			Class.forName("javafx.scene.paint.Color");
-			return true;
-		}  catch (ClassNotFoundException e) {
-			return false;
 		}
 	}
 }

--- a/src/main/java/net/querz/mcaselector/io/FileHelper.java
+++ b/src/main/java/net/querz/mcaselector/io/FileHelper.java
@@ -49,7 +49,11 @@ public final class FileHelper {
 	}
 
 	public static Point2i parseMCAFileName(File file) {
-		Matcher m = FileHelper.REGION_GROUP_PATTERN.matcher(file.getName());
+		return parseMCAFileName(file.getName());
+	}
+
+	public static Point2i parseMCAFileName(String name) {
+		Matcher m = FileHelper.REGION_GROUP_PATTERN.matcher(name);
 		if (m.find()) {
 			int x = Integer.parseInt(m.group("regionX"));
 			int z = Integer.parseInt(m.group("regionZ"));

--- a/src/main/java/net/querz/mcaselector/io/FileHelper.java
+++ b/src/main/java/net/querz/mcaselector/io/FileHelper.java
@@ -20,8 +20,6 @@ import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.nio.file.FileVisitResult.CONTINUE;
-
 public final class FileHelper {
 
 	public static final String MCA_FILE_PATTERN = "^r\\.-?\\d+\\.-?\\d+\\.mca$";
@@ -123,14 +121,14 @@ public final class FileHelper {
 			@Override
 			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 				Files.deleteIfExists(file);
-				return CONTINUE;
+				return FileVisitResult.CONTINUE;
 			}
 
 			@Override
 			public FileVisitResult postVisitDirectory(Path dir, IOException ex) throws IOException {
 				if (ex == null) {
 					Files.deleteIfExists(dir);
-					return CONTINUE;
+					return FileVisitResult.CONTINUE;
 				}
 				throw ex;
 			}

--- a/src/main/java/net/querz/mcaselector/io/FileHelper.java
+++ b/src/main/java/net/querz/mcaselector/io/FileHelper.java
@@ -7,6 +7,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -14,6 +19,8 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
 
 public final class FileHelper {
 
@@ -109,5 +116,24 @@ public final class FileHelper {
 		JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
 		Manifest manifest = jarConnection.getManifest();
 		return manifest.getMainAttributes();
+	}
+
+	public static void clearFolder(File dir) throws IOException {
+		Files.walkFileTree(dir.toPath(), new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.deleteIfExists(file);
+				return CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException ex) throws IOException {
+				if (ex == null) {
+					Files.deleteIfExists(dir);
+					return CONTINUE;
+				}
+				throw ex;
+			}
+		});
 	}
 }

--- a/src/main/java/net/querz/mcaselector/io/MCAChunkData.java
+++ b/src/main/java/net/querz/mcaselector/io/MCAChunkData.java
@@ -229,7 +229,7 @@ public class MCAChunkData {
 		level.putInt("zPos", level.getInt("zPos") + offset.blockToChunk().getY());
 
 		// adjust entity positions
-		if (level.containsKey("Entities")) {
+		if (level.containsKey("Entities") && level.get("Entities").getID() != CompoundTag.ID) {
 			ListTag<CompoundTag> entities = catchClassCastException(() -> level.getListTag("Entities").asCompoundTagList());
 			if (entities != null) {
 				entities.forEach(v -> applyOffsetToEntity(v, offset));
@@ -237,7 +237,7 @@ public class MCAChunkData {
 		}
 
 		// adjust tile entity positions
-		if (level.containsKey("TileEntities")) {
+		if (level.containsKey("TileEntities") && level.get("TileEntities").getID() == CompoundTag.ID) {
 			ListTag<CompoundTag> tileEntities = catchClassCastException(() -> level.getListTag("TileEntities").asCompoundTagList());
 			if (tileEntities != null) {
 				tileEntities.forEach(v -> applyOffsetToTileEntity(v, offset));

--- a/src/main/java/net/querz/mcaselector/point/Point2f.java
+++ b/src/main/java/net/querz/mcaselector/point/Point2f.java
@@ -81,6 +81,10 @@ public class Point2f implements Cloneable {
 		return div(i, i);
 	}
 
+	public Point2f abs() {
+		return new Point2f(x < 0 ? x * -1 : x, y < 0 ? y * -1 : y);
+	}
+
 	public Point2i toPoint2i() {
 		return new Point2i((int) x, (int) y);
 	}

--- a/src/main/java/net/querz/mcaselector/point/Point2i.java
+++ b/src/main/java/net/querz/mcaselector/point/Point2i.java
@@ -1,8 +1,9 @@
 package net.querz.mcaselector.point;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class Point2i implements Cloneable {
+public class Point2i implements Cloneable, Serializable {
 
 	private int x, z;
 

--- a/src/main/java/net/querz/mcaselector/point/Point2i.java
+++ b/src/main/java/net/querz/mcaselector/point/Point2i.java
@@ -108,6 +108,10 @@ public class Point2i implements Cloneable, Serializable {
 		return mod(f, f);
 	}
 
+	public Point2i and(int i) {
+		return new Point2i(x & i, z & i);
+	}
+
 	public Point2i abs() {
 		return new Point2i(x < 0 ? x * -1 : x, z < 0 ? z * -1 : z);
 	}

--- a/src/main/java/net/querz/mcaselector/point/Point2i.java
+++ b/src/main/java/net/querz/mcaselector/point/Point2i.java
@@ -124,6 +124,10 @@ public class Point2i implements Cloneable, Serializable {
 		return new Point2i(x << i, z << i);
 	}
 
+	public Point2f toPoint2f() {
+		return new Point2f((float) x, (float) z);
+	}
+
 	@Override
 	public boolean equals(Object other) {
 		return other instanceof Point2i

--- a/src/main/java/net/querz/mcaselector/text/TextHelper.java
+++ b/src/main/java/net/querz/mcaselector/text/TextHelper.java
@@ -1,6 +1,9 @@
 package net.querz.mcaselector.text;
 
 import net.querz.mcaselector.debug.Debug;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -95,5 +98,13 @@ public final class TextHelper {
 			s.insert(0, "0");
 		}
 		return s.toString();
+	}
+
+	public static String getStacktraceAsString(Exception ex) {
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		ex.printStackTrace(pw);
+		pw.flush();
+		return sw.toString();
 	}
 }

--- a/src/main/java/net/querz/mcaselector/text/Translation.java
+++ b/src/main/java/net/querz/mcaselector/text/Translation.java
@@ -42,6 +42,8 @@ public enum Translation {
 	MENU_VIEW_CLEAR_CACHE("menu.view.clear_cache"),
 	MENU_VIEW_CLEAR_ALL_CACHE("menu.view.clear_all_cache"),
 	MENU_SELECTION_CLEAR("menu.selection.clear"),
+	MENU_SELECTION_COPY_CHUNKS("menu.selection.copy_chunks"),
+	MENU_SELECTION_PASTE_CHUNKS("menu.selection.paste_chunks"),
 	MENU_SELECTION_EXPORT_CHUNKS("menu.selection.export_chunks"),
 	MENU_SELECTION_DELETE_CHUNKS("menu.selection.delete_chunks"),
 	MENU_SELECTION_IMPORT_SELECTION("menu.selection.import_selection"),

--- a/src/main/java/net/querz/mcaselector/tiles/Selection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/Selection.java
@@ -44,70 +44,60 @@ public class Selection implements Serializable {
 		min = new Point2i(Integer.MAX_VALUE, Integer.MAX_VALUE);
 		max = new Point2i(Integer.MIN_VALUE, Integer.MIN_VALUE);
 
-		Point2i minRegionX = new Point2i(Integer.MAX_VALUE, 0);
-		Point2i minRegionZ = new Point2i(0, Integer.MAX_VALUE);
-		Point2i maxRegionX = new Point2i(Integer.MIN_VALUE, 0);
-		Point2i maxRegionZ = new Point2i(0, Integer.MIN_VALUE);
+		int minRegionX = Integer.MAX_VALUE;
+		int minRegionZ = Integer.MAX_VALUE;
+		int maxRegionX = Integer.MIN_VALUE;
+		int maxRegionZ = Integer.MIN_VALUE;
 
 		for (Map.Entry<Point2i, Set<Point2i>> entry : selection.entrySet()) {
-			if (entry.getKey().getX() < minRegionX.getX()) {
-				minRegionX = entry.getKey();
-			}
-			if (entry.getKey().getY() < minRegionZ.getY()) {
-				minRegionZ = entry.getKey();
-			}
-			if (entry.getKey().getX() > maxRegionX.getX()) {
-				maxRegionX = entry.getKey();
-			}
-			if (entry.getKey().getY() > maxRegionZ.getY()) {
-				maxRegionZ = entry.getKey();
-			}
-		}
-
-		Set<Point2i> minRegionXChunks = selection.get(minRegionX);
-		if (minRegionXChunks == null) {
-			min.setX(minRegionX.regionToChunk().getX());
-		} else {
-			for (Point2i chunk : minRegionXChunks) {
-				if (chunk.getX() < min.getX()) {
-					min.setX(chunk.getX());
+			if (entry.getKey().getX() <= minRegionX) {
+				if (entry.getValue() == null) {
+					min.setX(entry.getKey().regionToChunk().getX());
+				} else {
+					for (Point2i chunk : entry.getValue()) {
+						if (chunk.getX() < min.getX()) {
+							min.setX(chunk.getX());
+						}
+					}
 				}
+				minRegionX = entry.getKey().getX();
 			}
-		}
-
-		Set<Point2i> minRegionZChunks = selection.get(minRegionZ);
-		if (minRegionZChunks == null) {
-			min.setY(minRegionZ.regionToChunk().getY());
-		} else {
-			for (Point2i chunk : minRegionZChunks) {
-				if (chunk.getY() < min.getY()) {
-					min.setY(chunk.getY());
+			if (entry.getKey().getY() <= minRegionZ) {
+				if (entry.getValue() == null) {
+					min.setY(entry.getKey().regionToChunk().getY());
+				} else {
+					for (Point2i chunk : entry.getValue()) {
+						if (chunk.getY() < min.getY()) {
+							min.setY(chunk.getY());
+						}
+					}
 				}
+				minRegionZ = entry.getKey().getY();
 			}
-		}
-
-		Set<Point2i> maxRegionXChunks = selection.get(maxRegionX);
-		if (maxRegionXChunks == null) {
-			max.setX(maxRegionX.regionToChunk().getX() + 31);
-		} else {
-			for (Point2i chunk : maxRegionXChunks) {
-				if (chunk.getX() > max.getX()) {
-					max.setX(chunk.getX());
+			if (entry.getKey().getX() >= maxRegionX) {
+				if (entry.getValue() == null) {
+					max.setX(entry.getKey().regionToChunk().getX() + 31);
+				} else {
+					for (Point2i chunk : entry.getValue()) {
+						if (chunk.getX() > max.getX()) {
+							max.setX(chunk.getX());
+						}
+					}
 				}
+				maxRegionX = entry.getKey().getX();
 			}
-		}
-
-		Set<Point2i> maxRegionZChunks = selection.get(maxRegionZ);
-		if (maxRegionZChunks == null) {
-			max.setY(maxRegionZ.regionToChunk().getY() + 31);
-		} else {
-			for (Point2i chunk : maxRegionZChunks) {
-				if (chunk.getY() > max.getY()) {
-					max.setY(chunk.getY());
+			if (entry.getKey().getY() >= maxRegionZ) {
+				if (entry.getValue() == null) {
+					max.setY(entry.getKey().regionToChunk().getY() + 31);
+				} else {
+					for (Point2i chunk : entry.getValue()) {
+						if (chunk.getY() > max.getY()) {
+							max.setY(chunk.getY());
+						}
+					}
 				}
+				maxRegionZ = entry.getKey().getY();
 			}
 		}
 	}
-
-
 }

--- a/src/main/java/net/querz/mcaselector/tiles/Selection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/Selection.java
@@ -103,7 +103,7 @@ public class Selection implements Serializable {
 		} else {
 			for (Point2i chunk : maxRegionZChunks) {
 				if (chunk.getY() > max.getY()) {
-					max.setX(chunk.getY());
+					max.setY(chunk.getY());
 				}
 			}
 		}

--- a/src/main/java/net/querz/mcaselector/tiles/Selection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/Selection.java
@@ -81,7 +81,7 @@ public class Selection implements Serializable {
 		} else {
 			for (Point2i chunk : minRegionZChunks) {
 				if (chunk.getY() < min.getY()) {
-					min.setX(chunk.getY());
+					min.setY(chunk.getY());
 				}
 			}
 		}

--- a/src/main/java/net/querz/mcaselector/tiles/Selection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/Selection.java
@@ -1,0 +1,113 @@
+package net.querz.mcaselector.tiles;
+
+import net.querz.mcaselector.point.Point2i;
+import java.io.File;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
+
+public class Selection implements Serializable {
+
+	private final Map<Point2i, Set<Point2i>> selection;
+	private Point2i min, max;
+	private final File world;
+
+	public Selection(Map<Point2i, Set<Point2i>> selection, File world) {
+		this.selection = selection;
+		this.world = world;
+		calculateMinMax();
+	}
+
+	public Map<Point2i, Set<Point2i>> getSelectionData() {
+		return selection;
+	}
+
+	public Point2i getMin() {
+		if (min == null) {
+			calculateMinMax();
+		}
+		return min;
+	}
+
+	public Point2i getMax() {
+		if (max == null) {
+			calculateMinMax();
+		}
+		return max;
+	}
+
+	public File getWorld() {
+		return world;
+	}
+
+	private void calculateMinMax() {
+		min = new Point2i(Integer.MAX_VALUE, Integer.MAX_VALUE);
+		max = new Point2i(Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+		Point2i minRegionX = new Point2i(Integer.MAX_VALUE, 0);
+		Point2i minRegionZ = new Point2i(0, Integer.MAX_VALUE);
+		Point2i maxRegionX = new Point2i(Integer.MIN_VALUE, 0);
+		Point2i maxRegionZ = new Point2i(0, Integer.MIN_VALUE);
+
+		for (Map.Entry<Point2i, Set<Point2i>> entry : selection.entrySet()) {
+			if (entry.getKey().getX() < minRegionX.getX()) {
+				minRegionX = entry.getKey();
+			}
+			if (entry.getKey().getY() < minRegionZ.getY()) {
+				minRegionZ = entry.getKey();
+			}
+			if (entry.getKey().getX() > maxRegionX.getX()) {
+				maxRegionX = entry.getKey();
+			}
+			if (entry.getKey().getY() > maxRegionZ.getY()) {
+				maxRegionZ = entry.getKey();
+			}
+		}
+
+		Set<Point2i> minRegionXChunks = selection.get(minRegionX);
+		if (minRegionXChunks == null) {
+			min.setX(minRegionX.regionToChunk().getX());
+		} else {
+			for (Point2i chunk : minRegionXChunks) {
+				if (chunk.getX() < min.getX()) {
+					min.setX(chunk.getX());
+				}
+			}
+		}
+
+		Set<Point2i> minRegionZChunks = selection.get(minRegionZ);
+		if (minRegionZChunks == null) {
+			min.setY(minRegionZ.regionToChunk().getY());
+		} else {
+			for (Point2i chunk : minRegionZChunks) {
+				if (chunk.getY() < min.getY()) {
+					min.setX(chunk.getY());
+				}
+			}
+		}
+
+		Set<Point2i> maxRegionXChunks = selection.get(maxRegionX);
+		if (maxRegionXChunks == null) {
+			max.setX(maxRegionX.regionToChunk().getX() + 31);
+		} else {
+			for (Point2i chunk : maxRegionXChunks) {
+				if (chunk.getX() > max.getX()) {
+					max.setX(chunk.getX());
+				}
+			}
+		}
+
+		Set<Point2i> maxRegionZChunks = selection.get(maxRegionZ);
+		if (maxRegionZChunks == null) {
+			max.setY(maxRegionZ.regionToChunk().getY() + 31);
+		} else {
+			for (Point2i chunk : maxRegionZChunks) {
+				if (chunk.getY() > max.getY()) {
+					max.setX(chunk.getY());
+				}
+			}
+		}
+	}
+
+
+}

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -13,15 +13,10 @@ import net.querz.mcaselector.key.KeyActivator;
 import net.querz.mcaselector.point.Point2f;
 import net.querz.mcaselector.point.Point2i;
 import net.querz.mcaselector.progress.Timer;
-import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.ClipboardOwner;
-import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -135,39 +130,6 @@ public class TileMap extends Canvas implements ClipboardOwner {
 			keyActivator.pressActionKey(event.getCode());
 		} else {
 			keyActivator.pressKey(event.getCode());
-
-			if (event.isShortcutDown() && event.getCode() == KeyCode.C) {
-				System.out.println("COPY");
-				Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-				Selection selection = new Selection(getMarkedChunks(), Config.getWorldDir());
-				TileMapSelection tileMapSelection = new TileMapSelection(selection);
-				clipboard.setContents(tileMapSelection, this);
-
-				System.out.println(getMarkedChunks());
-
-			} else if (event.isShortcutDown() && event.getCode() == KeyCode.V) {
-				Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-				Transferable content = clipboard.getContents(this);
-				DataFlavor[] flavors = content.getTransferDataFlavors();
-
-				Arrays.stream(flavors).forEach(System.out::println);
-
-				if (flavors.length == 1 && flavors[0].equals(TileMapSelection.selectionDataFlavor)) {
-					try {
-						Object data = content.getTransferData(flavors[0]);
-
-						Selection selection = (Selection) data;
-
-						System.out.println(selection.getSelectionData());
-
-						setMarkedChunks(selection.getSelectionData());
-						update();
-
-					} catch (UnsupportedFlavorException | IOException e) {
-						e.printStackTrace();
-					}
-				}
-			}
 		}
 	}
 

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -391,7 +391,8 @@ public class TileMap extends Canvas implements ClipboardOwner {
 			if (markedChunks.size() == 0) {
 				continue;
 			}
-			chunks.put(entry.getKey(), markedChunks);
+			// cloning marked chunks for clipboard copy-pasting in the same instance
+			chunks.put(entry.getKey(), new HashSet<>(markedChunks));
 		}
 		return chunks;
 	}

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -325,6 +325,10 @@ public class TileMap extends Canvas implements ClipboardOwner {
 		this.disabled = disabled;
 	}
 
+	public boolean getDisabled() {
+		return disabled;
+	}
+
 	public void setOnUpdate(Consumer<TileMap> listener) {
 		updateListener.add(listener);
 	}

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -496,11 +496,11 @@ public class TileMap extends Canvas implements ClipboardOwner {
 			pastedChunksOffset = null;
 		} else {
 			pastedChunksCache = new HashMap<>();
-
-			// paste into the middle of the screen
+			Point2i offsetInChunks = offset.toPoint2i().blockToChunk(); // 0|0
 			Point2i pastedMid = new Point2i((max.getX() - min.getX()) / 2, (max.getY() - min.getY()) / 2);
-			Point2f middle = offset.add((float) getWidth() * scale / 2, (float) getHeight() * scale / 2);
-			pastedChunksOffset = middle.toPoint2i().blockToChunk().add(pastedMid);
+			Point2i originOffset = offsetInChunks.sub(min).sub(pastedMid);
+			Point2f screenSizeInChunks = new Point2f(getWidth(), getHeight()).mul(scale).div(16);
+			pastedChunksOffset = originOffset.add(screenSizeInChunks.div(2).toPoint2i());
 		}
 	}
 
@@ -716,9 +716,6 @@ public class TileMap extends Canvas implements ClipboardOwner {
 		Point2i min = offset.sub(additionalOffset).toPoint2i().blockToRegion();
 		Point2i max = offset.sub(additionalOffset).add((float) getWidth() * scale, (float) getHeight() * scale).toPoint2i().blockToRegion();
 
-//		System.out.println("min: " + min);
-//		System.out.println("max: " + max);
-
 		Point2i mid = min.regionToBlock().add(max.regionToBlock()).div(2).blockToRegion().regionToBlock().blockToRegion();
 		int dir = 0; //0 = right, 1 = down, 2 = left, 3 = up
 		int steps = 1;
@@ -793,7 +790,7 @@ public class TileMap extends Canvas implements ClipboardOwner {
 	}
 
 	@Override
-	public void lostOwnership(Clipboard clipboard, Transferable transferable){
-		System.out.println("TileMap lost ownership");
+	public void lostOwnership(Clipboard clipboard, Transferable transferable) {
+		Debug.dump("TileMap lost ownership");
 	}
 }

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -20,6 +20,7 @@ import net.querz.mcaselector.progress.Timer;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.ClipboardOwner;
 import java.awt.datatransfer.Transferable;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -68,6 +69,7 @@ public class TileMap extends Canvas implements ClipboardOwner {
 	private final ImagePool imgPool;
 
 	private Map<Point2i, Set<Point2i>> pastedChunks;
+	private File pastedWorld;
 	private Map<Point2i, Image> pastedChunksCache;
 	private Point2i pastedChunksOffset;
 	private Point2i firstPastedChunksOffset;
@@ -147,6 +149,7 @@ public class TileMap extends Canvas implements ClipboardOwner {
 		if (event.getCode() == KeyCode.ESCAPE) {
 			Debug.dumpf("cancelling chunk pasting");
 			pastedChunks = null;
+			pastedWorld = null;
 			pastedChunksCache = null;
 			pastedChunksOffset = null;
 			update();
@@ -485,8 +488,9 @@ public class TileMap extends Canvas implements ClipboardOwner {
 		}
 	}
 
-	public void setPastedChunks(Map<Point2i, Set<Point2i>> chunks, Point2i min, Point2i max) {
+	public void setPastedChunks(Map<Point2i, Set<Point2i>> chunks, Point2i min, Point2i max, File pastedWorld) {
 		pastedChunks = chunks;
+		this.pastedWorld = pastedWorld;
 		if (chunks == null) {
 			pastedChunksCache = null;
 			pastedChunksOffset = null;
@@ -498,6 +502,22 @@ public class TileMap extends Canvas implements ClipboardOwner {
 			Point2f middle = offset.add((float) getWidth() * scale / 2, (float) getHeight() * scale / 2);
 			pastedChunksOffset = middle.toPoint2i().blockToChunk().add(pastedMid);
 		}
+	}
+
+	public Map<Point2i, Set<Point2i>> getPastedChunks() {
+		return pastedChunks;
+	}
+
+	public boolean isInPastingMode() {
+		return pastedChunks != null;
+	}
+
+	public File getPastedWorld() {
+		return pastedWorld;
+	}
+
+	public Point2i getPastedChunksOffset() {
+		return pastedChunksOffset;
 	}
 
 	private Point2i getMouseBlock(double x, double z) {

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -271,6 +271,17 @@ public class TileMap extends Canvas implements ClipboardOwner {
 		update();
 	}
 
+	public void redrawOverlays() {
+		for (Map.Entry<Point2i, Tile> entry : tiles.entrySet()) {
+			if (entry.getValue().markedChunksImage != null) {
+				TileImage.createMarkedChunksImage(entry.getValue(), getZoomLevel());
+			}
+		}
+		if (pastedChunksCache != null) {
+			pastedChunksCache.clear();
+		}
+	}
+
 	public void update() {
 		Timer t = new Timer();
 		runUpdateListeners();

--- a/src/main/java/net/querz/mcaselector/tiles/TileMap.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMap.java
@@ -395,6 +395,11 @@ public class TileMap extends Canvas implements ClipboardOwner {
 		visibleTiles.clear();
 		imgPool.clear();
 		selectedChunks = 0;
+
+		pastedChunks = null;
+		pastedWorld = null;
+		pastedChunksCache = null;
+		pastedChunksOffset = null;
 	}
 
 	public void clearTile(Point2i p) {

--- a/src/main/java/net/querz/mcaselector/tiles/TileMapSelection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMapSelection.java
@@ -1,5 +1,6 @@
 package net.querz.mcaselector.tiles;
 
+import net.querz.mcaselector.debug.Debug;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.ClipboardOwner;
 import java.awt.datatransfer.DataFlavor;
@@ -35,6 +36,6 @@ public class TileMapSelection implements Transferable, ClipboardOwner {
 
 	@Override
 	public void lostOwnership(Clipboard clipboard, Transferable contents) {
-		System.out.println("Selection lost ownership");
+		Debug.dump("Selection lost ownership");
 	}
 }

--- a/src/main/java/net/querz/mcaselector/tiles/TileMapSelection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMapSelection.java
@@ -8,8 +8,8 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 
 public class TileMapSelection implements Transferable, ClipboardOwner {
 
-	public static final DataFlavor selectionDataFlavor = new DataFlavor(Selection.class, "MCA Selector selection");
-	private Selection selection;
+	public static final DataFlavor SELECTION_DATA_FLAVOR = new DataFlavor(Selection.class, "MCA Selector selection");
+	private final Selection selection;
 
 	public TileMapSelection(Selection selection) {
 		this.selection = selection;
@@ -17,12 +17,12 @@ public class TileMapSelection implements Transferable, ClipboardOwner {
 
 	@Override
 	public DataFlavor[] getTransferDataFlavors() {
-		return new DataFlavor[] {selectionDataFlavor};
+		return new DataFlavor[] {SELECTION_DATA_FLAVOR};
 	}
 
 	@Override
 	public boolean isDataFlavorSupported(DataFlavor flavor) {
-		return selectionDataFlavor.equals(flavor);
+		return SELECTION_DATA_FLAVOR.equals(flavor);
 	}
 
 	@Override
@@ -30,7 +30,7 @@ public class TileMapSelection implements Transferable, ClipboardOwner {
 		if (isDataFlavorSupported(flavor)) {
 			return selection;
 		}
-		throw new UnsupportedFlavorException(selectionDataFlavor);
+		throw new UnsupportedFlavorException(SELECTION_DATA_FLAVOR);
 	}
 
 	@Override

--- a/src/main/java/net/querz/mcaselector/tiles/TileMapSelection.java
+++ b/src/main/java/net/querz/mcaselector/tiles/TileMapSelection.java
@@ -1,0 +1,40 @@
+package net.querz.mcaselector.tiles;
+
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+
+public class TileMapSelection implements Transferable, ClipboardOwner {
+
+	public static final DataFlavor selectionDataFlavor = new DataFlavor(Selection.class, "MCA Selector selection");
+	private Selection selection;
+
+	public TileMapSelection(Selection selection) {
+		this.selection = selection;
+	}
+
+	@Override
+	public DataFlavor[] getTransferDataFlavors() {
+		return new DataFlavor[] {selectionDataFlavor};
+	}
+
+	@Override
+	public boolean isDataFlavorSupported(DataFlavor flavor) {
+		return selectionDataFlavor.equals(flavor);
+	}
+
+	@Override
+	public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
+		if (isDataFlavorSupported(flavor)) {
+			return selection;
+		}
+		throw new UnsupportedFlavorException(selectionDataFlavor);
+	}
+
+	@Override
+	public void lostOwnership(Clipboard clipboard, Transferable contents) {
+		System.out.println("Selection lost ownership");
+	}
+}

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -201,9 +201,11 @@ public class DialogHelper {
 			Config.setMaxLoadedFiles(r.getMaxLoadedFiles());
 			Config.setRegionSelectionColor(new Color(r.getRegionColor()));
 			Config.setChunkSelectionColor(new Color(r.getChunkColor()));
+			Config.setPasteChunksColor(new Color(r.getPasteColor()));
 			Config.setShade(r.getShade());
 			Config.setShadeWater(r.getShadeWater());
 			Config.setDebug(r.getDebug());
+			tileMap.redrawOverlays();
 			tileMap.update();
 		});
 	}

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -298,11 +298,11 @@ public class DialogHelper {
 
 				System.out.println(selection.getSelectionData());
 
-				tileMap.setMarkedChunks(selection.getSelectionData());
+				tileMap.setPastedChunks(selection.getSelectionData());
 				tileMap.update();
 
-			} catch (UnsupportedFlavorException | IOException e) {
-				e.printStackTrace();
+			} catch (UnsupportedFlavorException | IOException ex) {
+				Debug.dumpException("failed to paste chunks", ex);
 			}
 		}
 	}

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -308,6 +308,11 @@ public class DialogHelper {
 
 					Selection selection = (Selection) data;
 
+					if (selection.getWorld().equals(Config.getWorldDir())) {
+						Debug.dump("cannot paste if source and target worlds are the same: " + Config.getWorldDir());
+						return;
+					}
+
 					tileMap.setPastedChunks(selection.getSelectionData(), selection.getMin(), selection.getMax(), selection.getWorld());
 					tileMap.update();
 

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -288,7 +288,7 @@ public class DialogHelper {
 	public static void pasteSelectedChunks(TileMap tileMap, Stage primaryStage) {
 		if (tileMap.isInPastingMode()) {
 			DataProperty<ImportConfirmationDialog.ChunkImportConfirmationData> dataProperty = new DataProperty<>();
-			ChunkImportConfirmationData preFill = new ChunkImportConfirmationData(tileMap.getPastedChunksOffset(), true, tileMap.getSelectedChunks() > 0, null);
+			ChunkImportConfirmationData preFill = new ChunkImportConfirmationData(tileMap.getPastedChunksOffset(), true, false, null);
 			Optional<ButtonType> result = new ImportConfirmationDialog(primaryStage, preFill, dataProperty::set).showAndWait();
 			result.ifPresent(r -> {
 				if (r == ButtonType.OK) {

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -274,13 +274,10 @@ public class DialogHelper {
 	}
 
 	public static void copySelectedChunks(TileMap tileMap) {
-		System.out.println("COPY");
 		Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 		Selection selection = new Selection(tileMap.getMarkedChunks(), Config.getWorldDir());
 		TileMapSelection tileMapSelection = new TileMapSelection(selection);
 		clipboard.setContents(tileMapSelection, tileMap);
-
-		System.out.println(tileMap.getMarkedChunks());
 	}
 
 	public static void pasteSelectedChunks(TileMap tileMap) {
@@ -288,17 +285,13 @@ public class DialogHelper {
 		Transferable content = clipboard.getContents(tileMap);
 		DataFlavor[] flavors = content.getTransferDataFlavors();
 
-		Arrays.stream(flavors).forEach(System.out::println);
-
 		if (flavors.length == 1 && flavors[0].equals(TileMapSelection.SELECTION_DATA_FLAVOR)) {
 			try {
 				Object data = content.getTransferData(flavors[0]);
 
 				Selection selection = (Selection) data;
 
-				System.out.println(selection.getSelectionData());
-
-				tileMap.setPastedChunks(selection.getSelectionData());
+				tileMap.setPastedChunks(selection.getSelectionData(), selection.getMin(), selection.getMax());
 				tileMap.update();
 
 			} catch (UnsupportedFlavorException | IOException ex) {

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -290,7 +290,7 @@ public class DialogHelper {
 
 		Arrays.stream(flavors).forEach(System.out::println);
 
-		if (flavors.length == 1 && flavors[0].equals(TileMapSelection.selectionDataFlavor)) {
+		if (flavors.length == 1 && flavors[0].equals(TileMapSelection.SELECTION_DATA_FLAVOR)) {
 			try {
 				Object data = content.getTransferData(flavors[0]);
 

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -382,7 +382,7 @@ public class DialogHelper {
 				tileMap.clear();
 				tileMap.update();
 				tileMap.disable(false);
-				optionBar.setWorldDependentMenuItemsEnabled(true);
+				optionBar.setWorldDependentMenuItemsEnabled(true, tileMap);
 			}
 		}
 	}

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -187,7 +187,11 @@ public class DialogHelper {
 					|| Config.getProcessThreads() != r.getProcessThreads()
 					|| Config.getWriteThreads() != r.getWriteThreads()
 					|| Config.getMaxLoadedFiles() != r.getMaxLoadedFiles()) {
-				MCAFilePipe.init(r.getReadThreads(), r.getProcessThreads(), r.getWriteThreads(), r.getMaxLoadedFiles());
+				Config.setLoadThreads(r.getReadThreads());
+				Config.setProcessThreads(r.getProcessThreads());
+				Config.setWriteThreads(r.getWriteThreads());
+				Config.setMaxLoadedFiles(r.getMaxLoadedFiles());
+				MCAFilePipe.init();
 			}
 
 			if (!Config.getLocale().equals(r.getLocale())) {
@@ -195,10 +199,6 @@ public class DialogHelper {
 				Locale.setDefault(Config.getLocale());
 				Translation.load(Config.getLocale());
 			}
-			Config.setLoadThreads(r.getReadThreads());
-			Config.setProcessThreads(r.getProcessThreads());
-			Config.setWriteThreads(r.getWriteThreads());
-			Config.setMaxLoadedFiles(r.getMaxLoadedFiles());
 			Config.setRegionSelectionColor(new Color(r.getRegionColor()));
 			Config.setChunkSelectionColor(new Color(r.getChunkColor()));
 			Config.setPasteChunksColor(new Color(r.getPasteColor()));

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -292,7 +292,7 @@ public class DialogHelper {
 	public static void pasteSelectedChunks(TileMap tileMap, Stage primaryStage) {
 		if (tileMap.isInPastingMode()) {
 			DataProperty<ImportConfirmationDialog.ChunkImportConfirmationData> dataProperty = new DataProperty<>();
-			ChunkImportConfirmationData preFill = new ChunkImportConfirmationData(tileMap.getPastedChunksOffset(), true, false, null);
+			ChunkImportConfirmationData preFill = new ChunkImportConfirmationData(tileMap.getPastedChunksOffset(), true, tileMap.getSelectedChunks() > 0, null);
 			Optional<ButtonType> result = new ImportConfirmationDialog(primaryStage, preFill, dataProperty::set).showAndWait();
 			result.ifPresent(r -> {
 				if (r == ButtonType.OK) {

--- a/src/main/java/net/querz/mcaselector/ui/ImportConfirmationDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/ImportConfirmationDialog.java
@@ -105,12 +105,16 @@ public class ImportConfirmationDialog extends ConfirmationDialog {
 
 		if (preFill != null) {
 			if (preFill.offset != null) {
+				data.offset = preFill.offset;
 				locationInput.setX(preFill.offset.getX());
 				locationInput.setZ(preFill.offset.getY());
 			}
+			data.overwrite = preFill.overwrite;
 			overwrite.setSelected(preFill.overwrite);
+			data.selectionOnly = preFill.selectionOnly;
 			selectionOnly.setSelected(preFill.selectionOnly);
 			if (preFill.ranges != null) {
+				data.ranges = preFill.ranges;
 				range.setText(preFill.ranges.stream().map(Range::toString).collect(Collectors.joining(",")));
 			}
 		}

--- a/src/main/java/net/querz/mcaselector/ui/ImportConfirmationDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/ImportConfirmationDialog.java
@@ -14,10 +14,11 @@ import net.querz.mcaselector.range.RangeParser;
 import net.querz.mcaselector.text.Translation;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class ImportConfirmationDialog extends ConfirmationDialog {
 
-	public ImportConfirmationDialog(Stage primaryStage, Consumer<ChunkImportConfirmationData> dataAction) {
+	public ImportConfirmationDialog(Stage primaryStage, ChunkImportConfirmationData preFill, Consumer<ChunkImportConfirmationData> dataAction) {
 		super(
 				primaryStage,
 				Translation.DIALOG_IMPORT_CHUNKS_CONFIRMATION_TITLE,
@@ -102,6 +103,17 @@ public class ImportConfirmationDialog extends ConfirmationDialog {
 		content.getChildren().addAll(options, confirmationLabels);
 		getDialogPane().setContent(content);
 
+		if (preFill != null) {
+			if (preFill.offset != null) {
+				locationInput.setX(preFill.offset.getX());
+				locationInput.setZ(preFill.offset.getY());
+			}
+			overwrite.setSelected(preFill.overwrite);
+			selectionOnly.setSelected(preFill.selectionOnly);
+			if (preFill.ranges != null) {
+				range.setText(preFill.ranges.stream().map(Range::toString).collect(Collectors.joining(",")));
+			}
+		}
 	}
 
 	public static class ChunkImportConfirmationData {
@@ -110,6 +122,15 @@ public class ImportConfirmationDialog extends ConfirmationDialog {
 		private boolean overwrite;
 		private boolean selectionOnly;
 		private List<Range> ranges;
+
+		private ChunkImportConfirmationData() {}
+
+		public ChunkImportConfirmationData(Point2i offset, boolean overwrite, boolean selectionOnly, List<Range> ranges) {
+			this.offset = offset;
+			this.overwrite = overwrite;
+			this.selectionOnly = selectionOnly;
+			this.ranges = ranges;
+		}
 
 		public Point2i getOffset() {
 			return offset;

--- a/src/main/java/net/querz/mcaselector/ui/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/OptionBar.java
@@ -82,7 +82,7 @@ public class OptionBar extends MenuBar {
 		clearViewCache.setOnAction(e -> CacheHelper.clearViewCache(tileMap));
 		clear.setOnAction(e -> tileMap.clearSelection());
 		copy.setOnAction(e -> DialogHelper.copySelectedChunks(tileMap));
-		paste.setOnAction(e -> DialogHelper.pasteSelectedChunks(tileMap));
+		paste.setOnAction(e -> DialogHelper.pasteSelectedChunks(tileMap, primaryStage));
 		exportChunks.setOnAction(e -> DialogHelper.exportSelectedChunks(tileMap, primaryStage));
 		importChunks.setOnAction(e -> DialogHelper.importChunks(tileMap, primaryStage));
 		delete.setOnAction(e -> DialogHelper.deleteSelection(tileMap, primaryStage));

--- a/src/main/java/net/querz/mcaselector/ui/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/OptionBar.java
@@ -34,6 +34,8 @@ public class OptionBar extends MenuBar {
 	private final MenuItem clearViewCache = UIFactory.menuItem(Translation.MENU_VIEW_CLEAR_CACHE);
 	private final MenuItem clearAllCache = UIFactory.menuItem(Translation.MENU_VIEW_CLEAR_ALL_CACHE);
 	private final MenuItem clear = UIFactory.menuItem(Translation.MENU_SELECTION_CLEAR);
+	private final MenuItem copy = UIFactory.menuItem(Translation.MENU_SELECTION_COPY_CHUNKS);
+	private final MenuItem paste = UIFactory.menuItem(Translation.MENU_SELECTION_PASTE_CHUNKS);
 	private final MenuItem exportChunks = UIFactory.menuItem(Translation.MENU_SELECTION_EXPORT_CHUNKS);
 	private final MenuItem importChunks = UIFactory.menuItem(Translation.MENU_TOOLS_IMPORT_CHUNKS);
 	private final MenuItem delete = UIFactory.menuItem(Translation.MENU_SELECTION_DELETE_CHUNKS);
@@ -59,6 +61,7 @@ public class OptionBar extends MenuBar {
 				clearViewCache, clearAllCache);
 		selection.getItems().addAll(
 				clear, UIFactory.separator(),
+				copy, paste, UIFactory.separator(),
 				exportChunks, delete, UIFactory.separator(),
 				importSelection, exportSelection, UIFactory.separator(),
 				clearSelectionCache);
@@ -78,6 +81,8 @@ public class OptionBar extends MenuBar {
 		clearAllCache.setOnAction(e -> CacheHelper.clearAllCache(tileMap));
 		clearViewCache.setOnAction(e -> CacheHelper.clearViewCache(tileMap));
 		clear.setOnAction(e -> tileMap.clearSelection());
+		copy.setOnAction(e -> DialogHelper.copySelectedChunks(tileMap));
+		paste.setOnAction(e -> DialogHelper.pasteSelectedChunks(tileMap));
 		exportChunks.setOnAction(e -> DialogHelper.exportSelectedChunks(tileMap, primaryStage));
 		importChunks.setOnAction(e -> DialogHelper.importChunks(tileMap, primaryStage));
 		delete.setOnAction(e -> DialogHelper.deleteSelection(tileMap, primaryStage));
@@ -98,6 +103,8 @@ public class OptionBar extends MenuBar {
 		clearAllCache.setAccelerator(new KeyCodeCombination(KeyCode.K, KeyCodeCombination.SHORTCUT_DOWN, KeyCodeCombination.SHIFT_DOWN));
 		clearViewCache.setAccelerator(new KeyCodeCombination(KeyCode.K, KeyCodeCombination.SHORTCUT_DOWN));
 		clear.setAccelerator(new KeyCodeCombination(KeyCode.L, KeyCodeCombination.SHORTCUT_DOWN));
+		copy.setAccelerator(new KeyCodeCombination(KeyCode.C, KeyCodeCombination.SHORTCUT_DOWN));
+		paste.setAccelerator(new KeyCodeCombination(KeyCode.V, KeyCodeCombination.SHORTCUT_DOWN));
 		exportChunks.setAccelerator(new KeyCodeCombination(KeyCode.E, KeyCodeCombination.SHORTCUT_DOWN, KeyCodeCombination.SHIFT_DOWN));
 		importChunks.setAccelerator(new KeyCodeCombination(KeyCode.I, KeyCodeCombination.SHORTCUT_DOWN, KeyCodeCombination.SHIFT_DOWN));
 		delete.setAccelerator(new KeyCodeCombination(KeyCode.D, KeyCodeCombination.SHORTCUT_DOWN));

--- a/src/main/java/net/querz/mcaselector/ui/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/OptionBar.java
@@ -1,12 +1,21 @@
 package net.querz.mcaselector.ui;
 
 import javafx.scene.control.*;
+import javafx.scene.control.Label;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.stage.Stage;
 import net.querz.mcaselector.tiles.TileMap;
 import net.querz.mcaselector.io.CacheHelper;
 import net.querz.mcaselector.text.Translation;
+import net.querz.mcaselector.tiles.TileMapSelection;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
 
 public class OptionBar extends MenuBar {
 	/*
@@ -117,7 +126,11 @@ public class OptionBar extends MenuBar {
 		swapChunks.setAccelerator(new KeyCodeCombination(KeyCode.M, KeyCodeCombination.SHORTCUT_DOWN));
 
 		setSelectionDependentMenuItemsEnabled(tileMap.getSelectedChunks());
-		setWorldDependentMenuItemsEnabled(false);
+		setWorldDependentMenuItemsEnabled(false, tileMap);
+
+		Toolkit.getDefaultToolkit().getSystemClipboard().addFlavorListener(e -> {
+			paste.setDisable(!hasValidClipboardContent(tileMap) || tileMap.getDisabled());
+		});
 	}
 
 	private void onUpdate(TileMap tileMap) {
@@ -128,10 +141,12 @@ public class OptionBar extends MenuBar {
 		previousSelectedChunks = selectedChunks;
 	}
 
-	public void setWorldDependentMenuItemsEnabled(boolean enabled) {
+	public void setWorldDependentMenuItemsEnabled(boolean enabled, TileMap tileMap) {
 		filterChunks.setDisable(!enabled);
 		changeFields.setDisable(!enabled);
 		importChunks.setDisable(!enabled);
+		copy.setDisable(!enabled);
+		paste.setDisable(!enabled || hasValidClipboardContent(tileMap));
 	}
 
 	private void setSelectionDependentMenuItemsEnabled(int selected) {
@@ -142,5 +157,12 @@ public class OptionBar extends MenuBar {
 		clearSelectionCache.setDisable(selected == 0);
 		editNBT.setDisable(selected != 1);
 		swapChunks.setDisable(selected != 2);
+	}
+
+	private boolean hasValidClipboardContent(TileMap tileMap) {
+		Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+		Transferable content = clipboard.getContents(tileMap);
+		DataFlavor[] flavors = content.getTransferDataFlavors();
+		return flavors.length == 1 && flavors[0].equals(TileMapSelection.SELECTION_DATA_FLAVOR);
 	}
 }

--- a/src/main/java/net/querz/mcaselector/ui/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/OptionBar.java
@@ -148,7 +148,7 @@ public class OptionBar extends MenuBar {
 		changeFields.setDisable(!enabled);
 		importChunks.setDisable(!enabled);
 		copy.setDisable(!enabled);
-		paste.setDisable(!enabled || hasValidClipboardContent(tileMap));
+		paste.setDisable(!enabled || !hasValidClipboardContent(tileMap));
 	}
 
 	private void setSelectionDependentMenuItemsEnabled(int selected) {

--- a/src/main/java/net/querz/mcaselector/ui/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/OptionBar.java
@@ -130,9 +130,7 @@ public class OptionBar extends MenuBar {
 		setSelectionDependentMenuItemsEnabled(tileMap.getSelectedChunks());
 		setWorldDependentMenuItemsEnabled(false, tileMap);
 
-		Toolkit.getDefaultToolkit().getSystemClipboard().addFlavorListener(e -> {
-			paste.setDisable(!hasValidClipboardContent(tileMap) || tileMap.getDisabled());
-		});
+		Toolkit.getDefaultToolkit().getSystemClipboard().addFlavorListener(e -> paste.setDisable(!hasValidClipboardContent(tileMap) || tileMap.getDisabled()));
 	}
 
 	private void onUpdate(TileMap tileMap) {
@@ -159,6 +157,7 @@ public class OptionBar extends MenuBar {
 		clearSelectionCache.setDisable(selected == 0);
 		editNBT.setDisable(selected != 1);
 		swapChunks.setDisable(selected != 2);
+		copy.setDisable(selected == 0);
 	}
 
 	private boolean hasValidClipboardContent(TileMap tileMap) {

--- a/src/main/java/net/querz/mcaselector/ui/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/OptionBar.java
@@ -21,10 +21,12 @@ public class OptionBar extends MenuBar {
 	/*
 	* File			View				Selection					Tools				About
 	* - Open		- Chunk Grid		- Clear selection			- Import chunks
-	* - Settings	- Region Grid		- Export selected chunks	- Filter chunks
-	* - Quit		- Goto				- Delete selected chunks	- Change fields
-	*				- Clear cache		- Import selection			- Edit NBT
-	*				- Clear all cache	- Export selection			- Swap chunks
+	* - Settings	- Region Grid		- Copy chunks				- Filter chunks
+	* - Quit		- Goto				- Paste chunks				- Change fields
+	*				- Clear cache		- Export selected chunks	- Edit NBT
+	*				- Clear all cache	- Delete selected chunks	- Swap chunks
+	*									- Import selection		
+	*									- Export selection		
 	*									- Clear cache
 	* */
 

--- a/src/main/java/net/querz/mcaselector/ui/SettingsDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/SettingsDialog.java
@@ -44,12 +44,14 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 	private final Slider maxLoadedFilesSlider = createSlider(1, (int) Math.ceil((double) maxMemory / 100_000_000L), 1, processorCount + processorCount / 2);
 	private final Button regionSelectionColorPreview = new Button();
 	private final Button chunkSelectionColorPreview = new Button();
+	private final Button pasteChunksColorPreview = new Button();
 	private final CheckBox shadeCheckBox = new CheckBox();
 	private final CheckBox shadeWaterCheckBox = new CheckBox();
 	private final CheckBox debugCheckBox = new CheckBox();
 
 	private Color regionSelectionColor = Config.getRegionSelectionColor().makeJavaFXColor();
 	private Color chunkSelectionColor = Config.getChunkSelectionColor().makeJavaFXColor();
+	private Color pasteChunksColor = Config.getPasteChunksColor().makeJavaFXColor();
 
 	private final ButtonType reset = new ButtonType(Translation.DIALOG_SETTINGS_RESET.toString(), ButtonBar.ButtonData.LEFT);
 
@@ -71,6 +73,8 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 			regionSelectionColorPreview.setBackground(new Background(new BackgroundFill(Config.DEFAULT_REGION_SELECTION_COLOR.makeJavaFXColor(), CornerRadii.EMPTY, Insets.EMPTY)));
 			chunkSelectionColor = Config.DEFAULT_CHUNK_SELECTION_COLOR.makeJavaFXColor();
 			chunkSelectionColorPreview.setBackground(new Background(new BackgroundFill(Config.DEFAULT_CHUNK_SELECTION_COLOR.makeJavaFXColor(), CornerRadii.EMPTY, Insets.EMPTY)));
+			pasteChunksColor = Config.DEFAULT_PASTE_CHUNKS_COLOR.makeJavaFXColor();
+			pasteChunksColorPreview.setBackground(new Background(new BackgroundFill(Config.DEFAULT_PASTE_CHUNKS_COLOR.makeJavaFXColor(), CornerRadii.EMPTY, Insets.EMPTY)));
 			shadeCheckBox.setSelected(Config.DEFAULT_SHADE);
 			shadeWaterCheckBox.setSelected(Config.DEFAULT_SHADE_WATER);
 			debugCheckBox.setSelected(Config.DEFAULT_DEBUG);
@@ -86,6 +90,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 						(int) maxLoadedFilesSlider.getValue(),
 						regionSelectionColor,
 						chunkSelectionColor,
+						pasteChunksColor,
 						shadeCheckBox.isSelected(),
 						shadeWaterCheckBox.isSelected(),
 						debugCheckBox.isSelected()
@@ -121,10 +126,13 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 
 		regionSelectionColorPreview.getStyleClass().clear();
 		chunkSelectionColorPreview.getStyleClass().clear();
+		pasteChunksColorPreview.getStyleClass().clear();
 		regionSelectionColorPreview.getStyleClass().add("color-preview-button");
 		chunkSelectionColorPreview.getStyleClass().add("color-preview-button");
+		pasteChunksColorPreview.getStyleClass().add("color-preview-button");
 		regionSelectionColorPreview.setBackground(new Background(new BackgroundFill(regionSelectionColor, CornerRadii.EMPTY, Insets.EMPTY)));
 		chunkSelectionColorPreview.setBackground(new Background(new BackgroundFill(chunkSelectionColor, CornerRadii.EMPTY, Insets.EMPTY)));
+		pasteChunksColorPreview.setBackground(new Background(new BackgroundFill(pasteChunksColor, CornerRadii.EMPTY, Insets.EMPTY)));
 		shadeCheckBox.setSelected(Config.shade());
 		shadeWaterCheckBox.setSelected(Config.shadeWater());
 		debugCheckBox.setSelected(Config.debug());
@@ -138,7 +146,17 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		});
 		chunkSelectionColorPreview.setOnMousePressed(e -> {
 			Optional<Color> result = new ColorPicker(getDialogPane().getScene().getWindow(), chunkSelectionColor).showColorPicker();
-			result.ifPresent(c -> chunkSelectionColor = c);
+			result.ifPresent(c -> {
+				chunkSelectionColor = c;
+				chunkSelectionColorPreview.setBackground(new Background(new BackgroundFill(c, CornerRadii.EMPTY, Insets.EMPTY)));
+			});
+		});
+		pasteChunksColorPreview.setOnMousePressed(e -> {
+			Optional<Color> result = new ColorPicker(getDialogPane().getScene().getWindow(), pasteChunksColor).showColorPicker();
+			result.ifPresent(c -> {
+				pasteChunksColor = c;
+				pasteChunksColorPreview.setBackground(new Background(new BackgroundFill(c, CornerRadii.EMPTY, Insets.EMPTY)));
+			});
 		});
 
 		shadeCheckBox.setOnAction(e -> shadeWaterCheckBox.setDisable(!shadeCheckBox.isSelected()));
@@ -153,9 +171,10 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_MAX_FILES), 0, 4, 1, 1);
 		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_REGION_COLOR), 0, 5, 1, 1);
 		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_CHUNK_COLOR), 0, 6, 1, 1);
-		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_SHADE), 0, 7, 1, 1);
-		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_SHADE_WATER), 0, 8, 1, 1);
-		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_PRINT_DEBUG), 0, 9, 1, 1);
+		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_REGION_COLOR), 0, 7, 1, 1);
+		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_SHADE), 0, 8, 1, 1);
+		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_SHADE_WATER), 0, 9, 1, 1);
+		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_PRINT_DEBUG), 0, 10, 1, 1);
 		grid.add(languages, 1, 0, 2, 1);
 		grid.add(readThreadsSlider, 1, 1, 1, 1);
 		grid.add(processThreadsSlider, 1, 2, 1, 1);
@@ -163,9 +182,10 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		grid.add(maxLoadedFilesSlider, 1, 4, 1, 1);
 		grid.add(regionSelectionColorPreview, 1, 5, 2, 1);
 		grid.add(chunkSelectionColorPreview, 1, 6, 2, 1);
-		grid.add(shadeCheckBox, 1, 7, 2, 1);
-		grid.add(shadeWaterCheckBox, 1, 8, 2, 1);
-		grid.add(debugCheckBox, 1, 9, 2, 1);
+		grid.add(pasteChunksColorPreview, 1, 7, 2, 1);
+		grid.add(shadeCheckBox, 1, 8, 2, 1);
+		grid.add(shadeWaterCheckBox, 1, 9, 2, 1);
+		grid.add(debugCheckBox, 1, 10, 2, 1);
 		grid.add(UIFactory.attachTextFieldToSlider(readThreadsSlider), 2, 1, 1, 1);
 		grid.add(UIFactory.attachTextFieldToSlider(processThreadsSlider), 2, 2, 1, 1);
 		grid.add(UIFactory.attachTextFieldToSlider(writeThreadsSlider), 2, 3, 1, 1);
@@ -185,13 +205,13 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 	public static class Result {
 
 		private final int readThreads, processThreads, writeThreads, maxLoadedFiles;
-		private final Color regionColor, chunkColor;
+		private final Color regionColor, chunkColor, pasteColor;
 		private final boolean shadeWater;
 		private final boolean shade;
 		private final boolean debug;
 		private final Locale locale;
 
-		public Result(Locale locale, int readThreads, int processThreads, int writeThreads, int maxLoadedFiles, Color regionColor, Color chunkColor, boolean shade, boolean shadeWater, boolean debug) {
+		public Result(Locale locale, int readThreads, int processThreads, int writeThreads, int maxLoadedFiles, Color regionColor, Color chunkColor, Color pasteColor, boolean shade, boolean shadeWater, boolean debug) {
 			this.locale = locale;
 			this.readThreads = readThreads;
 			this.processThreads = processThreads;
@@ -199,6 +219,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 			this.maxLoadedFiles = maxLoadedFiles;
 			this.regionColor = regionColor;
 			this.chunkColor = chunkColor;
+			this.pasteColor = pasteColor;
 			this.shade = shade;
 			this.shadeWater = shadeWater;
 			this.debug = debug;
@@ -230,6 +251,10 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 
 		public Color getChunkColor() {
 			return chunkColor;
+		}
+
+		public Color getPasteColor() {
+			return pasteColor;
 		}
 
 		public boolean getShade() {

--- a/src/main/java/net/querz/mcaselector/ui/SettingsDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/SettingsDialog.java
@@ -38,10 +38,10 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 
 	private final ComboBox<Locale> languages = new ComboBox<>();
 
-	private final Slider readThreadsSlider = createSlider(1, processorCount, 1, 1);
-	private final Slider processThreadsSlider = createSlider(1, processorCount * 2, 1, processorCount);
-	private final Slider writeThreadsSlider = createSlider(1, processorCount, 1, Math.min(processorCount, 4));
-	private final Slider maxLoadedFilesSlider = createSlider(1, (int) Math.ceil((double) maxMemory / 100_000_000L), 1, processorCount + processorCount / 2);
+	private final Slider readThreadsSlider = createSlider(1, processorCount, 1, Config.getLoadThreads());
+	private final Slider processThreadsSlider = createSlider(1, processorCount * 2, 1, Config.getProcessThreads());
+	private final Slider writeThreadsSlider = createSlider(1, processorCount, 1, Config.getWriteThreads());
+	private final Slider maxLoadedFilesSlider = createSlider(1, (int) Math.max(Math.ceil(maxMemory / 1_000_000_000D) * 6, 4), 1, Config.getMaxLoadedFiles());
 	private final Button regionSelectionColorPreview = new Button();
 	private final Button chunkSelectionColorPreview = new Button();
 	private final Button pasteChunksColorPreview = new Button();
@@ -119,10 +119,10 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		});
 		languages.getStyleClass().add("languages-combo-box");
 
-		readThreadsSlider.setValue(Config.getLoadThreads());
-		processThreadsSlider.setValue(Config.getProcessThreads());
-		writeThreadsSlider.setValue(Config.getWriteThreads());
-		maxLoadedFilesSlider.setValue(Config.getMaxLoadedFiles());
+//		readThreadsSlider.setValue(Config.getLoadThreads());
+//		processThreadsSlider.setValue(Config.getProcessThreads());
+//		writeThreadsSlider.setValue(Config.getWriteThreads());
+//		maxLoadedFilesSlider.setValue(Config.getMaxLoadedFiles());
 
 		regionSelectionColorPreview.getStyleClass().clear();
 		chunkSelectionColorPreview.getStyleClass().clear();

--- a/src/main/java/net/querz/mcaselector/ui/UIFactory.java
+++ b/src/main/java/net/querz/mcaselector/ui/UIFactory.java
@@ -26,6 +26,7 @@ public final class UIFactory {
 	public static MenuItem menuItem(Translation translation) {
 		MenuItem item = new MenuItem();
 		item.textProperty().bind(translation.getProperty());
+		item.setMnemonicParsing(false);
 		return item;
 	}
 

--- a/src/main/java/net/querz/mcaselector/ui/Window.java
+++ b/src/main/java/net/querz/mcaselector/ui/Window.java
@@ -51,6 +51,11 @@ public class Window extends Application {
 
 		scene.setOnKeyPressed(e -> pressedKeys.add(e.getCode()));
 		scene.setOnKeyReleased(e -> pressedKeys.remove(e.getCode()));
+		primaryStage.focusedProperty().addListener((obs, o, n) -> {
+			if (!n) {
+				pressedKeys.clear();
+			}
+		});
 
 		primaryStage.setOnCloseRequest(e -> System.exit(0));
 		primaryStage.setScene(scene);

--- a/src/main/resources/lang/cs_CZ.txt
+++ b/src/main/resources/lang/cs_CZ.txt
@@ -24,6 +24,8 @@ menu.view.goto;Přejít
 menu.view.clear_cache;Smazat keš
 menu.view.clear_all_cache;Smazat všechny keše
 menu.selection.clear;Vyčistit
+menu.selection.copy_chunks;Kopírovat chunky
+menu.selection.paste_chunks;Vložit chunky
 menu.selection.export_chunks;Exportovat vybrané chunky
 menu.selection.delete_chunks;Smazat vybrané chunky
 menu.selection.import_selection;Importovat výběr

--- a/src/main/resources/lang/de_DE.txt
+++ b/src/main/resources/lang/de_DE.txt
@@ -24,6 +24,8 @@ menu.view.goto;Gehe zu
 menu.view.clear_cache;Cache leeren
 menu.view.clear_all_cache;Gesamten Cache leeren
 menu.selection.clear;Zurücksetzen
+menu.selection.copy_chunks;Chunks kopieren
+menu.selection.paste_chunks;Chunks einfügen
 menu.selection.export_chunks;Selektierte Chunks exportieren
 menu.selection.delete_chunks;Selektierte Chunks löschen
 menu.selection.import_selection;Selektion importieren

--- a/src/main/resources/lang/en_GB.txt
+++ b/src/main/resources/lang/en_GB.txt
@@ -24,6 +24,8 @@ menu.view.goto;Goto
 menu.view.clear_cache;Clear cache
 menu.view.clear_all_cache;Clear all cache
 menu.selection.clear;Clear
+menu.selection.copy_chunks;Copy chunks
+menu.selection.paste_chunks;Paste chunks
 menu.selection.export_chunks;Export selected chunks
 menu.selection.delete_chunks;Delete selected chunks
 menu.selection.import_selection;Import selection

--- a/src/main/resources/lang/es_ES.txt
+++ b/src/main/resources/lang/es_ES.txt
@@ -24,6 +24,8 @@ menu.view.goto;Ir a
 menu.view.clear_cache;Limpiar caché
 menu.view.clear_all_cache;Limpiar toda la caché
 menu.selection.clear;Deseleccionar todo
+menu.selection.copy_chunks;Copiar chunks
+menu.selection.paste_chunks;Pegar chunks
 menu.selection.export_chunks;Exportar chunks seleccionados
 menu.selection.delete_chunks;Borrar chunks seleccionados
 menu.selection.import_selection;Importar una selección

--- a/src/main/resources/lang/fr_FR.txt
+++ b/src/main/resources/lang/fr_FR.txt
@@ -24,6 +24,8 @@ menu.view.goto;Aller à
 menu.view.clear_cache;Vider le cache
 menu.view.clear_all_cache;Nettoyer tout le cache
 menu.selection.clear;Nettoyer
+menu.selection.copy_chunks;Copier les chunks
+menu.selection.paste_chunks;Coller les chunks
 menu.selection.export_chunks;Exporter les chunks sélectionnés
 menu.selection.delete_chunks;Supprimer les chunks sélectionnés
 menu.selection.import_selection;Importer la selection

--- a/src/main/resources/lang/pt_BR.txt
+++ b/src/main/resources/lang/pt_BR.txt
@@ -24,6 +24,8 @@ menu.view.goto;Ir para
 menu.view.clear_cache;Limpar cache
 menu.view.clear_all_cache;Limpar todo o cache
 menu.selection.clear;Deselecionar tudo
+menu.selection.copy_chunks;Copiar chunks
+menu.selection.paste_chunks;Colar chunks
 menu.selection.export_chunks;Exportar chunks selecionados
 menu.selection.delete_chunks;Apagar chunks selecionados
 menu.selection.import_selection;Importar seleção

--- a/src/main/resources/lang/ru_RU.txt
+++ b/src/main/resources/lang/ru_RU.txt
@@ -24,6 +24,8 @@ menu.view.goto;Перейти по координатам
 menu.view.clear_cache;Отчистить кэш
 menu.view.clear_all_cache;Отчистить весь кэш
 menu.selection.clear;Сбросить
+menu.selection.copy_chunks;Копировать чанки
+menu.selection.paste_chunks;Вставить чанки
 menu.selection.export_chunks;Экспортировать выбранные чанки
 menu.selection.delete_chunks;Удалить выбранные чанки
 menu.selection.import_selection;Выбрать импорт

--- a/src/main/resources/lang/sv_SE.txt
+++ b/src/main/resources/lang/sv_SE.txt
@@ -24,6 +24,8 @@ menu.view.goto;Gå till
 menu.view.clear_cache;Rensa cache
 menu.view.clear_all_cache;Rensa all cache
 menu.selection.clear;Rensa
+menu.selection.copy_chunks;Kopiera chunks
+menu.selection.paste_chunks;Klistra in chunks
 menu.selection.export_chunks;Exportera valda chunks
 menu.selection.delete_chunks;Radera valda chunks
 menu.selection.import_selection;Importera markering

--- a/src/main/resources/lang/zh_CN.txt
+++ b/src/main/resources/lang/zh_CN.txt
@@ -24,6 +24,8 @@ menu.view.goto;转到
 menu.view.clear_cache;清除缓存
 menu.view.clear_all_cache;清除所有缓存
 menu.selection.clear;清除
+menu.selection.copy_chunks;复制块
+menu.selection.paste_chunks;粘贴大块
 menu.selection.export_chunks;导出选定的区块
 menu.selection.delete_chunks;删除选定的区块
 menu.selection.import_selection;导入所选内容

--- a/src/main/resources/lang/zh_TW.txt
+++ b/src/main/resources/lang/zh_TW.txt
@@ -24,6 +24,8 @@ menu.view.goto;轉到
 menu.view.clear_cache;清除緩存
 menu.view.clear_all_cache;清除所有緩存
 menu.selection.clear;清除
+menu.selection.copy_chunks;複製塊
+menu.selection.paste_chunks;粘貼大塊
 menu.selection.export_chunks;匯出已選擇的區塊
 menu.selection.delete_chunks;刪除已選擇的區塊
 menu.selection.import_selection;匯入已選擇的內容

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -398,8 +398,6 @@
 
 .tile-map-box {
 	-fx-effect: innershadow(gaussian, -color-tilemap-shadow, 8, 0, 0, 0);
-	-marked-region-color: rgba(255, 0, 0, 0.8);
-	-marked-chunk-color: rgba(255, 115, 0, 0.8);
 	-region-grid-color: black;
 	-chunk-grid-color: darkgray;
 	-grid-line-width: 0.5;


### PR DESCRIPTION
* Changed the default color for region selection to the same as chunk selection (orange) to avoid confusion. The colors can still be changed separately in the settings.
* Copy-Paste:
  * Make a selection
  * Use `Selections --> Copy chunks` or press `Ctrl+C` (`Cmd+C` on Mac) to copy the selection to the clipboard.
  * Go to where you want the selection to be pasted. Copying works through instances of MCA Selector, so you can even close and reopen the program! Open a different world, stay in the same world and navigate to the desired location.
  * Use `Selections --> Paste chunks` or press `Ctrl+V` (`Cmd+V` on Mac) to display an overlay that shows where the chunks would be pasted.
  * Move the overlay to the desired location by pressing and holding the `left mouse button`.
  * Pasting can be cancelled by pressing `Esc`.
  * Use `Selections --> Paste chunks` or press `Ctrl+V` again to open the `Import chunks` dialog, prefilled with the offset values according to your choice.
  * Make your choice with the remaining options and press `OK` to start the import.
* Added a new option in the settings to change the color of the Pasting overlay.
* Fixed a bug where key combinations that opened a dialog would be stuck and mess with scrolling and zooming on trackpads after closing the dialog.
* Tweaked the default values for the Threadpool so MCA Selector doesn't use 100% of all available processor cores.
* A dialog with an error is now shown before the program starts when JavaFX has not been found.
* Updated the screenshots and documentation in the Readme.
* Added translation to Portuguese (Portugal) (thanks to [@D3W10](https://github.com/D3W10) for translating).