### PR TITLE
1.12.1: Use OS standard directories for cache, logs, and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,19 @@ Copying can be cancelled by pressing `Esc`.
 When exactly two chunks are selected, they can be swapped using `Tools --> Swap chunks`. This is useful for corrupted region files when Minecraft failed to correctly save the region file index, resulting in scrambled chunks.
 
 ### Caching
-The tool creates an image for each region from the provided mca-files. These images are saved separately inside a `cache`-folder in the working directory of the program for future usage. Experience showed that a Minecraft world with a size of 10GB resulted in cached image files with a total size of 80-100MB. Caching as many regions as possible significantly improves loading times though.
+The tool creates an image for each region from the provided mca-files. These images are saved separately inside the respective operating system's specific cache folders. Experience showed that a Minecraft world with a size of 10GB resulted in cached image files with a total size of 80-100MB. Caching as many regions as possible significantly improves loading times.
+* Windows: `%LOCALAPPDATA%\mcaselector\cache` if `%LOCALAPPDATA%` is set, otherwise `<parent directory of mcaselector.jar>\mcaselector\cache`
+* MacOS: `~/Library/Caches/mcaselector`
+* Linux: `$XDG_CACHE_DIR/mcaselector` if `$XDG_CACHE_DIR` is set, otherwise `~/.cache/mcaselector`
 
 ### Debugging
-If something is not working properly or if you want to see the exact query that is run using the chunk filter, debugging can be enabled in the settings. It will print useful information about what the program is currently doing to the console.
+If something is not working properly or if you want to see what exactly the MCA Selector is doing, debugging can be enabled in the settings. Informative messages and errors will be printed to the console as well as to a log file.
+The log file is stored in the following directory and is overwritten after each new start of the program:
+* Windows: `%LOCALAPPDATA%\mcaselector\debug.log` if `%LOCALAPPDATA%` is set, otherwise `<parent directory of mcaselector.jar>\mcaselector\debug.log`
+* MacOS: `~/.log/mcaselector/debug.log`
+* Linux: `~/.log/mcaselector/debug.log`
+
+Alternatively, the location of the log file can be viewed by clicking on the link in the settings dialog.
 
 ---
 ## Supported Versions
@@ -181,7 +190,7 @@ The MCA Selector currently supports the following Minecraft versions:
 | 1.13 - 1.13.2     | 1444 - 1631 |
 | 1.14 - 1.14.4     | 1901 - 1976 |
 | 1.15 - 1.15.2     | 2200 - 2230 |
-| 1.16-rc1 - ?      | 2564 - ?    |
+| 1.16 - ?          | 2566 - ?    |
 
 There is no guarantee for worlds generated in a Snapshot version to work, even if it is specified in the table above. This only represents the current development status towards the next Minecraft release. Old Snapshots of past Minecraft releases are not supported.
 
@@ -328,7 +337,7 @@ If you would like to contribute a translation, you can find the language files i
 
 ## Download and installation
 
-[**Download Version 1.12**](https://github.com/Querz/mcaselector/releases/download/1.12/mcaselector-1.12.jar)
+[**Download Version 1.12.1**](https://github.com/Querz/mcaselector/releases/download/1.12.1/mcaselector-1.12.1.jar)
 
 "Requirements":
 * Either:
@@ -340,11 +349,11 @@ If you would like to contribute a translation, you can find the language files i
 
 #### If you have Java from Oracle installed on your system
 
-Most likely, `.jar` files are associated with java on your computer, it should therefore launch by simply double clicking the file (or however your OS is configured to open files using your mouse or keyboard). If not, you can try `java -jar mcaselector-1.12.jar` from your console. If this doesn't work, you might want to look into how to modify the `PATH` variable on your system to tell your system that java is an executable program.
+Most likely, `.jar` files are associated with java on your computer, it should therefore launch by simply double clicking the file (or however your OS is configured to open files using your mouse or keyboard). If not, you can try `java -jar mcaselector-1.12.1.jar` from your console. If this doesn't work, you might want to look into how to modify the `PATH` variable on your system to tell your system that java is an executable program.
 
 #### If you have Minecraft Java Edition installed on your system
 
-Minecraft Java Edition comes with a JRE that you can use to start the MCA Selector, so there is no need to install another version of java on your system. On Windows, that java version is usually located in `C:\Program Files (x86)\Minecraft\runtime\jre-x64\bin\` and once inside this folder you can simply run `java.exe -jar <path-to-mcaselector-1.12.jar>`. On Mac OS you should find it in `~/Library/Application\ Support/minecraft/runtime/jre-x64/jre.bundle/Contents/Home/bin/` where you can execute `./java -jar <path-to-mcaselector-1.12.jar>`.
+Minecraft Java Edition comes with a JRE that you can use to start the MCA Selector, so there is no need to install another version of java on your system. On Windows, that java version is usually located in `C:\Program Files (x86)\Minecraft\runtime\jre-x64\bin\` and once inside this folder you can simply run `java.exe -jar <path-to-mcaselector-1.12.1.jar>`. On Mac OS you should find it in `~/Library/Application\ Support/minecraft/runtime/jre-x64/jre.bundle/Contents/Home/bin/` where you can execute `./java -jar <path-to-mcaselector-1.12.1.jar>`.
 
 **WARNING:** For macOS 10.14+ (Mojave) It is NOT recommended to use the JRE provided by Minecraft (1.8.0_74), because it contains a severe bug that causes JavaFX applications to crash when they lose focus while a dialog window (such as the save-file-dialog) is open (see the bug report [here](https://bugs.openjdk.java.net/browse/JDK-8211304)). This bug has been fixed in Java 1.8.0_201 and above.
 
@@ -358,12 +367,12 @@ If you are using Java 11 or higher, the JavaFX modules are not included automati
 
 On Windows with Oracle Java 13:
 ```
-"C:\Program Files\Java\jdk-13.0.1\bin\java.exe" --module-path "C:\Program Files\Java\javafx-sdk-13.0.1\lib" --add-modules ALL-MODULE-PATH -jar mcaselector-1.12.jar
+"C:\Program Files\Java\jdk-13.0.1\bin\java.exe" --module-path "C:\Program Files\Java\javafx-sdk-13.0.1\lib" --add-modules ALL-MODULE-PATH -jar mcaselector-1.12.1.jar
 ```
 
 On Debian with OpenJDK 11 and openjfx:
 ```
-java --module-path /usr/share/openjfx/lib --add-modules ALL-MODULE-PATH -jar mcaselector-1.12.jar
+java --module-path /usr/share/openjfx/lib --add-modules ALL-MODULE-PATH -jar mcaselector-1.12.1.jar
 ```
 
 ##

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'idea'
 apply plugin: 'css'
 
 group 'net.querz.mcaselector'
-version '1.12'
+version '1.12.1'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -37,21 +37,31 @@ public final class Config {
 	static {
 		String osName = System.getProperty("os.name").toLowerCase();
 		if (osName.contains("mac")) {
-			DEFAULT_BASE_CACHE_DIR = new File(System.getProperty("user.home"), "/Library/Caches/mcaselector");
-			DEFAULT_BASE_LOG_FILE = new File(System.getProperty("user.home"), "/.log/mcaselector/mcaselector.debug.log");
-			DEFAULT_BASE_CONFIG_FILE = new File(System.getProperty("user.home"), "/Library/Application Support/mcaselector/settings.ini");
+			DEFAULT_BASE_CACHE_DIR = new File(System.getProperty("user.home"), "Library/Caches/mcaselector");
+			DEFAULT_BASE_LOG_FILE = new File(System.getProperty("user.home"), ".log/mcaselector/debug.log");
+			DEFAULT_BASE_CONFIG_FILE = new File(System.getProperty("user.home"), "Library/Application Support/mcaselector/settings.ini");
 		} else if (osName.contains("windows")) {
-			DEFAULT_BASE_CACHE_DIR = new File("%LOCALAPPDATA%/mcaselector");
-			DEFAULT_BASE_LOG_FILE = new File("%LOCALAPPDATA%/mcaselector/mcaslector.debug.log");
-			DEFAULT_BASE_CONFIG_FILE = new File("%LOCALAPPDATA%/mcaselector/settings.ini");
+			String localAppData = System.getenv("LOCALAPPDATA");
+			File localAppDataFile;
+			if (localAppData == null || localAppData.isEmpty()) {
+				localAppDataFile = DEFAULT_BASE_DIR;
+			} else {
+				localAppDataFile = new File(localAppData);
+			}
+			DEFAULT_BASE_CACHE_DIR = new File(localAppDataFile, "mcaselector/cache");
+			DEFAULT_BASE_LOG_FILE = new File(localAppDataFile, "mcaselector/debug.log");
+			DEFAULT_BASE_CONFIG_FILE = new File(localAppDataFile, "mcaselector/settings.ini");
 		} else {
 			String linuxCacheDir = System.getenv("XDG_CACHE_DIR");
+			File linuxCacheDirFile;
 			if (linuxCacheDir == null || linuxCacheDir.isEmpty()) {
-				linuxCacheDir = System.getProperty("user.home") + "/.cache/mcaselector";
+				linuxCacheDirFile = new File(System.getProperty("user.home"), ".cache");
+			} else {
+				linuxCacheDirFile = new File(linuxCacheDir);
 			}
-			DEFAULT_BASE_CACHE_DIR = new File(linuxCacheDir);
-			DEFAULT_BASE_LOG_FILE = new File(System.getProperty("user.homte"), "/.log/mcaselector/mcaselector.debug.log");
-			DEFAULT_BASE_CONFIG_FILE = new File(System.getProperty("user.home"), "/.mcaselector");
+			DEFAULT_BASE_CACHE_DIR = new File(linuxCacheDirFile, "mcaselector");
+			DEFAULT_BASE_LOG_FILE = new File(System.getProperty("user.home"), ".log/mcaselector/debug.log");
+			DEFAULT_BASE_CONFIG_FILE = new File(System.getProperty("user.home"), ".mcaselector");
 		}
 
 		if (!DEFAULT_BASE_CACHE_DIR.exists()) {

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -243,10 +243,6 @@ public final class Config {
 					"LogFile",
 					DEFAULT_BASE_LOG_FILE.getAbsolutePath()).replace("{user.dir}", userDir)
 			);
-			configFile = new File(config.getOrDefault(
-					"ConfigFile",
-					DEFAULT_BASE_CONFIG_FILE.getAbsolutePath()).replace("{user.dir}", userDir)
-			);
 
 			String localeString = config.getOrDefault("Locale", DEFAULT_LOCALE.toString());
 			String[] localeSplit = localeString.split("_");
@@ -278,10 +274,6 @@ public final class Config {
 				"LogFile",
 				logFile.getAbsolutePath().startsWith(userDir) ? logFile.getAbsolutePath().replace(userDir, "{user.dir}") : logFile.getAbsolutePath(),
 				DEFAULT_BASE_LOG_FILE.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
-		addSettingsLine(
-				"ConfigFile",
-				configFile.getAbsolutePath().startsWith(userDir) ? configFile.getAbsolutePath().replace(userDir, "{user.dir}") : configFile.getAbsolutePath(),
-				DEFAULT_BASE_CONFIG_FILE.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
 		addSettingsLine("Locale", locale.toString(), DEFAULT_LOCALE.toString(), lines);
 		addSettingsLine("RegionSelectionColor", regionSelectionColor.toString(), DEFAULT_REGION_SELECTION_COLOR.toString(), lines);
 		addSettingsLine("ChunkSelectionColor", chunkSelectionColor.toString(), DEFAULT_CHUNK_SELECTION_COLOR.toString(), lines);

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -215,6 +215,7 @@ public final class Config {
 		if (!configFile.exists()) {
 			return;
 		}
+		String userDir = DEFAULT_BASE_DIR.getAbsolutePath();
 		Map<String, String> config = new HashMap<>();
 		try {
 			Files.lines(configFile.toPath()).forEach(l -> {
@@ -236,15 +237,15 @@ public final class Config {
 			//set values
 			baseCacheDir = new File(config.getOrDefault(
 					"BaseCacheDir",
-					baseCacheDir.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_CACHE_DIR.getAbsolutePath())
+					DEFAULT_BASE_CACHE_DIR.getAbsolutePath()).replace("{user.dir}", userDir)
 			);
 			logFile = new File(config.getOrDefault(
 					"LogFile",
-					logFile.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_LOG_FILE.getAbsolutePath())
+					DEFAULT_BASE_LOG_FILE.getAbsolutePath()).replace("{user.dir}", userDir)
 			);
 			configFile = new File(config.getOrDefault(
 					"ConfigFile",
-					configFile.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_CONFIG_FILE.getAbsolutePath())
+					DEFAULT_BASE_CONFIG_FILE.getAbsolutePath()).replace("{user.dir}", userDir)
 			);
 
 			String localeString = config.getOrDefault("Locale", DEFAULT_LOCALE.toString());

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -38,7 +38,7 @@ public final class Config {
 		String osName = System.getProperty("os.name").toLowerCase();
 		if (osName.contains("mac")) {
 			DEFAULT_BASE_CACHE_DIR = new File(System.getProperty("user.home"), "/Library/Caches/mcaselector");
-			DEFAULT_BASE_LOG_FILE = new File("/var/log/mcaselector.debug.log");
+			DEFAULT_BASE_LOG_FILE = new File(System.getProperty("user.home"), "/.log/mcaselector/mcaselector.debug.log");
 			DEFAULT_BASE_CONFIG_FILE = new File(System.getProperty("user.home"), "/Library/Application Support/mcaselector/settings.ini");
 		} else if (osName.contains("windows")) {
 			DEFAULT_BASE_CACHE_DIR = new File("%LOCALAPPDATA%/mcaselector");
@@ -50,7 +50,7 @@ public final class Config {
 				linuxCacheDir = System.getProperty("user.home") + "/.cache/mcaselector";
 			}
 			DEFAULT_BASE_CACHE_DIR = new File(linuxCacheDir);
-			DEFAULT_BASE_LOG_FILE = new File("/var/log/mcaselector.debug.log");
+			DEFAULT_BASE_LOG_FILE = new File(System.getProperty("user.homte"), "/.log/mcaselector/mcaselector.debug.log");
 			DEFAULT_BASE_CONFIG_FILE = new File(System.getProperty("user.home"), "/.mcaselector");
 		}
 
@@ -80,6 +80,8 @@ public final class Config {
 	private static File worldDir = null;
 	private static UUID worldUUID = null;
 	private static File baseCacheDir = DEFAULT_BASE_CACHE_DIR;
+	private static File logFile = DEFAULT_BASE_LOG_FILE;
+	private static File configFile = DEFAULT_BASE_CONFIG_FILE;
 	private static File cacheDir = null;
 
 	private static Locale locale = DEFAULT_LOCALE;
@@ -140,6 +142,18 @@ public final class Config {
 		return cacheDirs;
 	}
 
+	public static File getBaseCacheDir() {
+		return baseCacheDir;
+	}
+
+	public static File getLogFile() {
+		return logFile;
+	}
+
+	public static File getConfigFile() {
+		return configFile;
+	}
+
 	public static void setShade(boolean shade) {
 		Config.shade = shade;
 	}
@@ -188,12 +202,12 @@ public final class Config {
 	}
 
 	public static void loadFromIni() {
-		if (!DEFAULT_BASE_CONFIG_FILE.exists()) {
+		if (!configFile.exists()) {
 			return;
 		}
 		Map<String, String> config = new HashMap<>();
 		try {
-			Files.lines(DEFAULT_BASE_CONFIG_FILE.toPath()).forEach(l -> {
+			Files.lines(configFile.toPath()).forEach(l -> {
 				if (l.charAt(0) == ';') {
 					return;
 				}
@@ -211,8 +225,16 @@ public final class Config {
 		try {
 			//set values
 			baseCacheDir = new File(config.getOrDefault(
-				"BaseCacheDir",
-				baseCacheDir.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_CACHE_DIR.getAbsolutePath())
+					"BaseCacheDir",
+					baseCacheDir.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_CACHE_DIR.getAbsolutePath())
+			);
+			logFile = new File(config.getOrDefault(
+					"LogFile",
+					logFile.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_LOG_FILE.getAbsolutePath())
+			);
+			configFile = new File(config.getOrDefault(
+					"ConfigFile",
+					configFile.getAbsolutePath()).replace("{user.dir}", DEFAULT_BASE_CONFIG_FILE.getAbsolutePath())
 			);
 
 			String localeString = config.getOrDefault("Locale", DEFAULT_LOCALE.toString());
@@ -238,9 +260,17 @@ public final class Config {
 		String userDir = DEFAULT_BASE_DIR.getAbsolutePath();
 		List<String> lines = new ArrayList<>(8);
 		addSettingsLine(
-			"BaseCacheDir",
-			baseCacheDir.getAbsolutePath().replace(userDir, "{user.dir}"),
-			DEFAULT_BASE_CACHE_DIR.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
+				"BaseCacheDir",
+				baseCacheDir.getAbsolutePath().replace(userDir, "{user.dir}"),
+				DEFAULT_BASE_CACHE_DIR.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
+		addSettingsLine(
+				"LogFile",
+				logFile.getAbsolutePath().replace(userDir, "{user.dir}"),
+				DEFAULT_BASE_LOG_FILE.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
+		addSettingsLine(
+				"ConfigFile",
+				configFile.getAbsolutePath().replace(userDir, "{user.dir}"),
+				DEFAULT_BASE_CONFIG_FILE.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
 		addSettingsLine("Locale", locale.toString(), DEFAULT_LOCALE.toString(), lines);
 		addSettingsLine("RegionSelectionColor", regionSelectionColor.toString(), DEFAULT_REGION_SELECTION_COLOR.toString(), lines);
 		addSettingsLine("ChunkSelectionColor", chunkSelectionColor.toString(), DEFAULT_CHUNK_SELECTION_COLOR.toString(), lines);
@@ -259,7 +289,7 @@ public final class Config {
 			return;
 		}
 		try {
-			Files.write(DEFAULT_BASE_CONFIG_FILE.toPath(), lines);
+			Files.write(configFile.toPath(), lines);
 		} catch (IOException ex) {
 			Debug.dumpException("error writing settings.ini", ex);
 		}

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -223,13 +223,13 @@ public final class Config {
 				}
 				String[] elements = l.split("=", 2);
 				if (elements.length != 2) {
-					Debug.errorf("invalid line in settings.ini: \"%s\"", l);
+					Debug.errorf("invalid line in settings: \"%s\"", l);
 					return;
 				}
 				config.put(elements[0], elements[1]);
 			});
 		} catch (IOException ex) {
-			Debug.dumpException("failed to read settings.ini", ex);
+			Debug.dumpException("failed to read settings", ex);
 		}
 
 		try {
@@ -262,7 +262,7 @@ public final class Config {
 			shadeWater = Boolean.parseBoolean(config.getOrDefault("ShadeWater", DEFAULT_SHADE_WATER + ""));
 			debug = Boolean.parseBoolean(config.getOrDefault("Debug", DEFAULT_DEBUG + ""));
 		} catch (Exception ex) {
-			Debug.dumpException("error loading settings.ini", ex);
+			Debug.dumpException("error loading settings", ex);
 		}
 	}
 
@@ -301,7 +301,7 @@ public final class Config {
 		try {
 			Files.write(configFile.toPath(), lines);
 		} catch (IOException ex) {
-			Debug.dumpException("error writing settings.ini", ex);
+			Debug.dumpException("error writing settings", ex);
 		}
 	}
 

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -261,15 +261,15 @@ public final class Config {
 		List<String> lines = new ArrayList<>(8);
 		addSettingsLine(
 				"BaseCacheDir",
-				baseCacheDir.getAbsolutePath().replace(userDir, "{user.dir}"),
+				baseCacheDir.getAbsolutePath().startsWith(userDir) ? baseCacheDir.getAbsolutePath().replace(userDir, "{user.dir}") : baseCacheDir.getAbsolutePath(),
 				DEFAULT_BASE_CACHE_DIR.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
 		addSettingsLine(
 				"LogFile",
-				logFile.getAbsolutePath().replace(userDir, "{user.dir}"),
+				logFile.getAbsolutePath().startsWith(userDir) ? logFile.getAbsolutePath().replace(userDir, "{user.dir}") : logFile.getAbsolutePath(),
 				DEFAULT_BASE_LOG_FILE.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
 		addSettingsLine(
 				"ConfigFile",
-				configFile.getAbsolutePath().replace(userDir, "{user.dir}"),
+				configFile.getAbsolutePath().startsWith(userDir) ? configFile.getAbsolutePath().replace(userDir, "{user.dir}") : configFile.getAbsolutePath(),
 				DEFAULT_BASE_CONFIG_FILE.getAbsolutePath().replace(userDir, "{user.dir}"), lines);
 		addSettingsLine("Locale", locale.toString(), DEFAULT_LOCALE.toString(), lines);
 		addSettingsLine("RegionSelectionColor", regionSelectionColor.toString(), DEFAULT_REGION_SELECTION_COLOR.toString(), lines);

--- a/src/main/java/net/querz/mcaselector/debug/Debug.java
+++ b/src/main/java/net/querz/mcaselector/debug/Debug.java
@@ -112,7 +112,7 @@ public final class Debug {
 
 		LogWriter() {
 			try {
-				br = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("debug.log")));
+				br = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(Config.getLogFile())));
 			} catch (IOException ex) {
 				ex.printStackTrace();
 				System.exit(0);
@@ -186,11 +186,16 @@ public final class Debug {
 
 		Properties sysProps = System.getProperties();
 		sysProps.list(System.out);
+		System.out.printf("cache.dir: %s\n", Config.getBaseCacheDir().getAbsolutePath());
+		System.out.printf("config.file: %s\n", Config.getConfigFile().getAbsolutePath());
+		System.out.printf("log.file: %s\n", Config.getLogFile().getAbsolutePath());
 
 		Debug.dumpf("os.name:                      %s", System.getProperty("os.name"));
 		Debug.dumpf("os.version:                   %s", System.getProperty("os.version"));
 		Debug.dumpf("user.dir:                     %s", System.getProperty("user.dir"));
-		Debug.dumpf("cache.dir:                    %s", Config.DEFAULT_BASE_CACHE_DIR.getAbsolutePath());
+		Debug.dumpf("cache.dir:                    %s", Config.getBaseCacheDir().getAbsolutePath());
+		Debug.dumpf("config.file:                  %s", Config.getConfigFile().getAbsolutePath());
+		Debug.dumpf("log.file                      %s", Config.getLogFile().getAbsolutePath());
 		Debug.dumpf("proc.cores:                   %s", Runtime.getRuntime().availableProcessors());
 		Debug.dumpf("java.version:                 %s", System.getProperty("java.version"));
 		Debug.dumpf("java.vm.specification.vendor: %s", System.getProperty("java.vm.specification.vendor"));

--- a/src/main/java/net/querz/mcaselector/debug/Debug.java
+++ b/src/main/java/net/querz/mcaselector/debug/Debug.java
@@ -184,12 +184,6 @@ public final class Debug {
 			logWriter = new LogWriter();
 		}
 
-		Properties sysProps = System.getProperties();
-		sysProps.list(System.out);
-		System.out.printf("cache.dir: %s\n", Config.getBaseCacheDir().getAbsolutePath());
-		System.out.printf("config.file: %s\n", Config.getConfigFile().getAbsolutePath());
-		System.out.printf("log.file: %s\n", Config.getLogFile().getAbsolutePath());
-
 		Debug.dumpf("os.name:                      %s", System.getProperty("os.name"));
 		Debug.dumpf("os.version:                   %s", System.getProperty("os.version"));
 		Debug.dumpf("user.dir:                     %s", System.getProperty("user.dir"));

--- a/src/main/java/net/querz/mcaselector/text/Translation.java
+++ b/src/main/java/net/querz/mcaselector/text/Translation.java
@@ -65,6 +65,7 @@ public enum Translation {
 	DIALOG_SETTINGS_SHADE("dialog.settings.shade"),
 	DIALOG_SETTINGS_SHADE_WATER("dialog.settings.shade_water"),
 	DIALOG_SETTINGS_PRINT_DEBUG("dialog.settings.print_debug"),
+	DIALOG_SETTINGS_SHOW_LOG_FILE("dialog.settings.show_log_file"),
 	DIALOG_SETTINGS_RESET("dialog.settings.reset"),
 	DIALOG_GOTO_TITLE("dialog.goto.title"),
 	DIALOG_CONFIRMATION_QUESTION("dialog.confirmation.question"),
@@ -278,7 +279,7 @@ public enum Translation {
 			Enumeration<JarEntry> entries = jar.entries();
 			Set<String> result = new HashSet<>();
 
-			while(entries.hasMoreElements()) {
+			while (entries.hasMoreElements()) {
 				String name = entries.nextElement().getName();
 				if (name.startsWith(path)) {
 					String entry = name.substring(path.length());

--- a/src/main/java/net/querz/mcaselector/ui/AboutDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/AboutDialog.java
@@ -19,10 +19,7 @@ import net.querz.mcaselector.debug.Debug;
 import net.querz.mcaselector.io.FileHelper;
 import net.querz.mcaselector.github.VersionChecker;
 import net.querz.mcaselector.text.Translation;
-import java.awt.Desktop;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.function.Consumer;
 
 public class AboutDialog extends Alert {
@@ -69,7 +66,7 @@ public class AboutDialog extends Alert {
 		ImageView imgView = new ImageView(githubMark);
 		imgView.setScaleX(0.5);
 		imgView.setScaleY(0.5);
-		Hyperlink source = createHyperlink("GitHub", "https://github.com/Querz/mcaselector", imgView);
+		Hyperlink source = UIFactory.hyperlink("GitHub", "https://github.com/Querz/mcaselector", imgView);
 		grid.add(source, 1, 3);
 
 		getDialogPane().setContent(grid);
@@ -89,7 +86,7 @@ public class AboutDialog extends Alert {
 				if (version != null && version.isNewerThan(applicationVersion)) {
 					HBox box = new HBox();
 					String hyperlinkText = version.getTag() + (version.isPrerelease() ? " (pre)" : "");
-					Hyperlink download = createHyperlink(hyperlinkText, version.getLink(), null);
+					Hyperlink download = UIFactory.hyperlink(hyperlinkText, version.getLink(), null);
 					download.getStyleClass().add("hyperlink-update");
 					Label arrow = new Label("\u2192");
 					arrow.getStyleClass().add("label-hint");
@@ -112,24 +109,5 @@ public class AboutDialog extends Alert {
 
 		lookup.setDaemon(true);
 		lookup.start();
-	}
-
-	private Hyperlink createHyperlink(String text, String url, Node graphic) {
-		Hyperlink hyperlink;
-		if (graphic == null) {
-			hyperlink = new Hyperlink(text);
-		} else {
-			hyperlink = new Hyperlink(text, graphic);
-		}
-		hyperlink.setOnAction(e -> {
-			if (Desktop.isDesktopSupported()) {
-				try {
-					Desktop.getDesktop().browse(new URL(url).toURI());
-				} catch (IOException | URISyntaxException ex) {
-					Debug.dumpException("cannot open url using a default browser", ex);
-				}
-			}
-		});
-		return hyperlink;
 	}
 }

--- a/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
+++ b/src/main/java/net/querz/mcaselector/ui/DialogHelper.java
@@ -185,14 +185,13 @@ public class DialogHelper {
 		result.ifPresent(r -> {
 			if (Config.getLoadThreads() != r.getReadThreads()
 					|| Config.getProcessThreads() != r.getProcessThreads()
-					|| Config.getWriteThreads() != r.getWriteThreads()
-					|| Config.getMaxLoadedFiles() != r.getMaxLoadedFiles()) {
+					|| Config.getWriteThreads() != r.getWriteThreads()) {
 				Config.setLoadThreads(r.getReadThreads());
 				Config.setProcessThreads(r.getProcessThreads());
 				Config.setWriteThreads(r.getWriteThreads());
-				Config.setMaxLoadedFiles(r.getMaxLoadedFiles());
 				MCAFilePipe.init();
 			}
+			Config.setMaxLoadedFiles(r.getMaxLoadedFiles());
 
 			if (!Config.getLocale().equals(r.getLocale())) {
 				Config.setLocale(r.getLocale());

--- a/src/main/java/net/querz/mcaselector/ui/SettingsDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/SettingsDialog.java
@@ -7,6 +7,7 @@ import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
@@ -119,11 +120,6 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		});
 		languages.getStyleClass().add("languages-combo-box");
 
-//		readThreadsSlider.setValue(Config.getLoadThreads());
-//		processThreadsSlider.setValue(Config.getProcessThreads());
-//		writeThreadsSlider.setValue(Config.getWriteThreads());
-//		maxLoadedFilesSlider.setValue(Config.getMaxLoadedFiles());
-
 		regionSelectionColorPreview.getStyleClass().clear();
 		chunkSelectionColorPreview.getStyleClass().clear();
 		pasteChunksColorPreview.getStyleClass().clear();
@@ -162,6 +158,11 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		shadeCheckBox.setOnAction(e -> shadeWaterCheckBox.setDisable(!shadeCheckBox.isSelected()));
 		shadeWaterCheckBox.setDisable(!shadeCheckBox.isSelected());
 
+		HBox debugBox = new HBox();
+		debugBox.getStyleClass().add("debug-box");
+		Hyperlink logFileLink = UIFactory.explorerLink(Translation.DIALOG_SETTINGS_SHOW_LOG_FILE, Config.getLogFile().getParentFile(), null);
+		debugBox.getChildren().addAll(debugCheckBox, logFileLink);
+
 		GridPane grid = new GridPane();
 		grid.getStyleClass().add("slider-grid-pane");
 		grid.add(UIFactory.label(Translation.DIALOG_SETTINGS_LANGUAGE), 0, 0, 1, 1);
@@ -185,7 +186,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		grid.add(pasteChunksColorPreview, 1, 7, 2, 1);
 		grid.add(shadeCheckBox, 1, 8, 2, 1);
 		grid.add(shadeWaterCheckBox, 1, 9, 2, 1);
-		grid.add(debugCheckBox, 1, 10, 2, 1);
+		grid.add(debugBox, 1, 10, 2, 1);
 		grid.add(UIFactory.attachTextFieldToSlider(readThreadsSlider), 2, 1, 1, 1);
 		grid.add(UIFactory.attachTextFieldToSlider(processThreadsSlider), 2, 2, 1, 1);
 		grid.add(UIFactory.attachTextFieldToSlider(writeThreadsSlider), 2, 3, 1, 1);

--- a/src/main/java/net/querz/mcaselector/ui/UIFactory.java
+++ b/src/main/java/net/querz/mcaselector/ui/UIFactory.java
@@ -1,8 +1,10 @@
 package net.querz.mcaselector.ui;
 
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.CheckMenuItem;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
@@ -11,7 +13,14 @@ import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
+import net.querz.mcaselector.debug.Debug;
 import net.querz.mcaselector.text.Translation;
+
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 public final class UIFactory {
 
@@ -95,5 +104,45 @@ public final class UIFactory {
 		});
 		sliderValue.setText((int) slider.getValue() + "");
 		return sliderValue;
+	}
+
+	public static Hyperlink hyperlink(String text, String url, Node graphic) {
+		Hyperlink hyperlink;
+		if (graphic == null) {
+			hyperlink = new Hyperlink(text);
+		} else {
+			hyperlink = new Hyperlink(text, graphic);
+		}
+		hyperlink.setOnAction(e -> {
+			if (Desktop.isDesktopSupported()) {
+				try {
+					Desktop.getDesktop().browse(new URL(url).toURI());
+				} catch (IOException | URISyntaxException ex) {
+					Debug.dumpException("cannot open url using a default browser", ex);
+				}
+			}
+		});
+		return hyperlink;
+	}
+
+	public static Hyperlink explorerLink(Translation text, File file, Node graphic) {
+		Hyperlink hyperlink;
+		if (graphic == null) {
+			hyperlink = new Hyperlink();
+		} else {
+			hyperlink = new Hyperlink("", graphic);
+		}
+		hyperlink.textProperty().bind(text.getProperty());
+
+		hyperlink.setOnAction(e -> {
+			if (Desktop.isDesktopSupported()) {
+				try {
+					Desktop.getDesktop().open(file);
+				} catch (IOException ex) {
+					Debug.dumpException("cannot open file or directory", ex);
+				}
+			}
+		});
+		return hyperlink;
 	}
 }

--- a/src/main/resources/lang/cs_CZ.txt
+++ b/src/main/resources/lang/cs_CZ.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Barva vybraného chunku
 dialog.settings.shade;Odstín
 dialog.settings.shade_water;Hloubka vody
 dialog.settings.print_debug;Vypisovat ladící zprávy
+dialog.settings.show_log_file;Zobrazit soubor protokolu
 dialog.settings.reset;Obnovit
 dialog.goto.title;Přejít na pozici
 dialog.confirmation.question;Jste si jisti?

--- a/src/main/resources/lang/de_DE.txt
+++ b/src/main/resources/lang/de_DE.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Farbe selektierter Chunk
 dialog.settings.shade;Schatten
 dialog.settings.shade_water;Wassertiefe
 dialog.settings.print_debug;Debug
+dialog.settings.show_log_file;Log-Datei anzeigen
 dialog.settings.reset;Zurücksetzen
 dialog.goto.title;Gehe zu Koordinaten
 dialog.confirmation.question;Bist Du dir sicher?

--- a/src/main/resources/lang/en_GB.txt
+++ b/src/main/resources/lang/en_GB.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Chunk selection color
 dialog.settings.shade;Shade
 dialog.settings.shade_water;Shade water
 dialog.settings.print_debug;Print debug messages
+dialog.settings.show_log_file;Show log file
 dialog.settings.reset;Reset
 dialog.goto.title;Goto location
 dialog.confirmation.question;Are you sure?

--- a/src/main/resources/lang/es_ES.txt
+++ b/src/main/resources/lang/es_ES.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Color de los Chunks
 dialog.settings.shade;Volumen 3D
 dialog.settings.shade_water;Profundidad del agua
 dialog.settings.print_debug;Mostrar mensajes de desarrolador
+dialog.settings.show_log_file;Mostrar archivo de registro
 dialog.settings.reset;Resetear
 dialog.goto.title;Ir a coordenadas
 dialog.confirmation.question;¿Está seguro?

--- a/src/main/resources/lang/fr_FR.txt
+++ b/src/main/resources/lang/fr_FR.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Couleur de sélection des chunks
 dialog.settings.shade;Ombre
 dialog.settings.shade_water;Profondeur d'eau
 dialog.settings.print_debug;Logger des messages de debug
+dialog.settings.show_log_file;Afficher le fichier journal
 dialog.settings.reset;Réinitialiser
 dialog.goto.title;Aller à une position
 dialog.confirmation.question;Êtes-vous sur ?

--- a/src/main/resources/lang/pt_BR.txt
+++ b/src/main/resources/lang/pt_BR.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Cor dos chunks
 dialog.settings.shade;Sombra
 dialog.settings.shade_water;Profundidade da água
 dialog.settings.print_debug;Mostrar mensagens de desenvolvedor
+dialog.settings.show_log_file;Mostrar arquivo de log
 dialog.settings.reset;Resetar
 dialog.goto.title;Ir para coordenadas
 dialog.confirmation.question;Tem certeza?

--- a/src/main/resources/lang/pt_PT.txt
+++ b/src/main/resources/lang/pt_PT.txt
@@ -24,6 +24,8 @@ menu.view.goto;Ir para
 menu.view.clear_cache;Limpar cache
 menu.view.clear_all_cache;Limpar todo o cache
 menu.selection.clear;Deselecionar tudo
+menu.selection.copy_chunks;Copiar chunks
+menu.selection.paste_chunks;Colar chunks
 menu.selection.export_chunks;Exportar chunks selecionados
 menu.selection.delete_chunks;Apagar chunks selecionados
 menu.selection.import_selection;Importar seleção
@@ -45,6 +47,7 @@ dialog.settings.chunk_color;Cor dos chunks
 dialog.settings.shade;Sombra
 dialog.settings.shade_water;Profundidade da água
 dialog.settings.print_debug;Mostrar mensagens de desenvolvedor
+dialog.settings.show_log_file;Mostrar arquivo de log
 dialog.settings.reset;Repor
 dialog.goto.title;Ir para coordenadas
 dialog.confirmation.question;Tem a certeza?

--- a/src/main/resources/lang/ru_RU.txt
+++ b/src/main/resources/lang/ru_RU.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Цвет выделяемых чанков
 dialog.settings.shade;тень
 dialog.settings.shade_water;Глубина воды
 dialog.settings.print_debug;Отображать системные сообщения
+dialog.settings.show_log_file;Показать файл журнала
 dialog.settings.reset;Сбросить
 dialog.goto.title;Перейти по координатам
 dialog.confirmation.question;Вы уверены?

--- a/src/main/resources/lang/sv_SE.txt
+++ b/src/main/resources/lang/sv_SE.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;Chunkmarkeringsfärg
 dialog.settings.shade;Skugga
 dialog.settings.shade_water;Vattendjup
 dialog.settings.print_debug;Skriv ut felsökningsmeddelanden
+dialog.settings.show_log_file;Visa loggfil
 dialog.settings.reset;Återställ
 dialog.goto.title;Gå till plats
 dialog.confirmation.question;Är du säker?

--- a/src/main/resources/lang/zh_CN.txt
+++ b/src/main/resources/lang/zh_CN.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;区块选择颜色
 dialog.settings.shade;阴影
 dialog.settings.shade_water;水深
 dialog.settings.print_debug;打印调试消息
+dialog.settings.show_log_file;显示日志文件
 dialog.settings.reset;重置
 dialog.goto.title;转到位置
 dialog.confirmation.question;你确定吗?

--- a/src/main/resources/lang/zh_TW.txt
+++ b/src/main/resources/lang/zh_TW.txt
@@ -47,6 +47,7 @@ dialog.settings.chunk_color;已選擇區塊的顏色標示
 dialog.settings.shade;陰影
 dialog.settings.shade_water;水深
 dialog.settings.print_debug;列印偵錯訊息
+dialog.settings.show_log_file;顯示日誌文件
 dialog.settings.reset;重置
 dialog.goto.title;轉到位置
 dialog.confirmation.question;你確定嗎？

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -330,16 +330,18 @@
 	-fx-padding: 8 15 8 0;
 }
 
-.about-dialog-pane .about-dialog-grid-pane .hyperlink:visited  {
-	-fx-text-fill: -color-text-light;
-}
-
 .about-dialog-pane .about-dialog-grid-pane .hyperlink .label {
 	-fx-padding: 0;
 }
 
 .about-dialog-pane .about-dialog-grid-pane .label-hint {
 	-fx-padding: 0 0 0 15;
+}
+
+/*---------- HYPERLINK ----------*/
+
+.hyperlink:visited  {
+	-fx-text-fill: -color-text-light;
 }
 
 /*---------- PROGRESS DIALOG ----------*/
@@ -574,7 +576,7 @@
 
 .slider-grid-pane .slider {
 	-fx-pref-width: 200;
-	-fx-padding: 0 10 0 10;
+	-fx-padding: 0 10 0 0;
 }
 
 .color-preview-button {
@@ -583,6 +585,10 @@
 
 .slider-grid-pane .label {
 	-fx-padding: 10 10 10 0;
+}
+
+.slider-grid-pane .debug-box {
+	-fx-padding: 4 0 -3 0;
 }
 
 .languages-combo-box {


### PR DESCRIPTION
* Fixed a bug where importing chunks with an offset would not correctly relocate TileEntities.
* Copying Entities now generates new UUIDs so Minecraft doesn't delete Entities with duplicate UUIDs.
* Changed default directories to make use of OS directories for cache, log files and settings:
  * Windows:
    * Cache directory: `%LOCALAPPDATA%\mcaselector\cache` if `%LOCALAPPDATA%` is set, otherwise `<parent directory of mcaselector.jar>\mcaselector\cache`
    * Log file: `%LOCALAPPDATA%\mcaselector\debug.log` if `%LOCALAPPDATA%` is set, otherwise `<parent directory of mcaselector.jar>\mcaselector\debug.log`
    * Config file: `%LOCALAPPDATA%\mcaselector\settings.ini` if `%LOCALAPPDATA%` is set, otherwise `<parent directory of mcaselector.jar>\mcaselector\settings.ini`
  * MacOS:
    * Cache directory: `~/Library/Caches/mcaselector`
    * Log file: `~/.log/mcaselector/debug.log`
    * Settings file: `~/Library/Application Support/mcaselector/settings.ini`
  * Linux:
    * Cache directory: `$XDG_CACHE_DIR/mcaselector` if `$XDG_CACHE_DIR` is set, otherwise `~/.cache/mcaselector`
    * Log file: `~/.log/mcaselector/debug.log`
    * Config file: `~/.mcaselector`
* The cache directory and log file can be configured by adding the options `BaseCacheDir` and `LogFile` to the config file. In headless mode when generating cache files, the output directory must still be provided with the `--output` parameter.
* The log file directory can now be opened by clicking a link in the settings.
* Updated the Readme accordingly.