### PR TITLE
Filter negation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Because the conditions use internal values used by Minecraft, the following tabl
 | Condition | Type | Description |
 | --------- | ----- | ----------- |
 | Group | - | Groups multiple conditions. |
+| Not Group | - | A negated group. |
 | DataVersion | int | The DataVersion tag of the chunk. 100-1343 for 1.12.2 and below, 1444 for 1.13 snapshots and above. |
 | InhabitedTime | long | The total amount of time in game-ticks players have spent in that chunk. 1 second ~20 ticks. Also accepts a duration string such as `1 year 2 months 3 days 4 hours 5 minutes 6 seconds`. |
 | LastUpdate | int | The time a chunk was last updated in seconds since 1970-01-01. Also accepts a timestamp in the `yyyy-MM-dd HH-mm-ss`-format such as `2018-01-02 15:03:04`. If the time is omitted, it will default to `00:00:00`. |
@@ -341,6 +342,8 @@ If you would like to contribute a translation, you can find the language files i
 ## Download and installation
 
 [**Download Version 1.12.3**](https://github.com/Querz/mcaselector/releases/download/1.12.3/mcaselector-1.12.3.jar)
+
+**MCA Selector modifies and deletes chunks in your Minecraft world. Please make backups of your world before using.**
 
 "Requirements":
 * Either:

--- a/src/main/java/net/querz/mcaselector/filter/FilterType.java
+++ b/src/main/java/net/querz/mcaselector/filter/FilterType.java
@@ -1,30 +1,31 @@
 package net.querz.mcaselector.filter;
 
-import net.querz.mcaselector.debug.Debug;
+import java.util.function.Supplier;
 
 public enum FilterType {
 
-	GROUP("Group", GroupFilter.class, Format.GROUP),
-	DATA_VERSION("DataVersion", DataVersionFilter.class, Format.NUMBER),
-	INHABITED_TIME("InhabitedTime", InhabitedTimeFilter.class, Format.NUMBER),
-	X_POS("xPos", XPosFilter.class, Format.NUMBER),
-	Z_POS("zPos", ZPosFilter.class, Format.NUMBER),
-	LAST_UPDATE("LastUpdate", LastUpdateFilter.class, Format.NUMBER),
-	PALETTE("Palette", PaletteFilter.class, Format.TEXT),
-	BIOME("Biome", BiomeFilter.class, Format.TEXT),
-	STATUS("Status", StatusFilter.class, Format.TEXT),
-	LIGHT_POPULATED("LightPopulated", LightPopulatedFilter.class, Format.NUMBER),
-	ENTITIES("Entities", EntityFilter.class, Format.TEXT),
-	ENTITY_AMOUNT("#Entities", EntityAmountFilter.class, Format.NUMBER),
-	TILE_ENTITY_AMOUNT("#TileEntities", TileEntityAmountFilter.class, Format.NUMBER);
+	GROUP("Group", GroupFilter::new, Format.GROUP),
+	NOT_GROUP("Not Group", () -> new GroupFilter(true), Format.GROUP),
+	DATA_VERSION("DataVersion", DataVersionFilter::new, Format.NUMBER),
+	INHABITED_TIME("InhabitedTime", InhabitedTimeFilter::new, Format.NUMBER),
+	X_POS("xPos", XPosFilter::new, Format.NUMBER),
+	Z_POS("zPos", ZPosFilter::new, Format.NUMBER),
+	LAST_UPDATE("LastUpdate", LastUpdateFilter::new, Format.NUMBER),
+	PALETTE("Palette", PaletteFilter::new, Format.TEXT),
+	BIOME("Biome", BiomeFilter::new, Format.TEXT),
+	STATUS("Status", StatusFilter::new, Format.TEXT),
+	LIGHT_POPULATED("LightPopulated", LightPopulatedFilter::new, Format.NUMBER),
+	ENTITIES("Entities", EntityFilter::new, Format.TEXT),
+	ENTITY_AMOUNT("#Entities", EntityAmountFilter::new, Format.NUMBER),
+	TILE_ENTITY_AMOUNT("#TileEntities", TileEntityAmountFilter::new, Format.NUMBER);
 
 	private final String string;
-	private final Class<? extends Filter<?>> clazz;
+	private final Supplier<? extends Filter<?>> creator;
 	private final Format format;
 
-	FilterType(String string, Class<? extends Filter<?>> clazz, Format format) {
+	FilterType(String string, Supplier<? extends Filter<?>> creator, Format format) {
 		this.string = string;
-		this.clazz = clazz;
+		this.creator = creator;
 		this.format = format;
 	}
 
@@ -33,12 +34,7 @@ public enum FilterType {
 	}
 
 	public Filter<?> create() {
-		try {
-			return clazz.newInstance();
-		} catch (InstantiationException | IllegalAccessException ex) {
-			Debug.dumpException("failed to create new filter instance", ex);
-		}
-		return null;
+		return creator.get();
 	}
 
 	@Override

--- a/src/main/java/net/querz/mcaselector/filter/GroupFilter.java
+++ b/src/main/java/net/querz/mcaselector/filter/GroupFilter.java
@@ -13,6 +13,11 @@ public class GroupFilter extends Filter<List<Filter<?>>> {
 		super(FilterType.GROUP);
 	}
 
+	public GroupFilter(boolean negated) {
+		super(FilterType.GROUP);
+		setNegated(negated);
+	}
+
 	public GroupFilter(Operator operator) {
 		super(FilterType.GROUP, operator);
 	}
@@ -25,6 +30,11 @@ public class GroupFilter extends Filter<List<Filter<?>>> {
 		filter.setParent(this);
 		children.add(filter);
 		return children.size() - 1;
+	}
+
+	@Override
+	public FilterType getType() {
+		return negated ? FilterType.NOT_GROUP : FilterType.GROUP;
 	}
 
 	public void setNegated(boolean negated) {
@@ -127,12 +137,25 @@ public class GroupFilter extends Filter<List<Filter<?>>> {
 	}
 
 	private String toString(int depth) {
-		StringBuilder s = new StringBuilder(depth == 0 ? "" : (negated ? "!(" : "("));
+		// add !(...) always
+		// add (...) if depth is not 0
+		// don't add empty groups
+
+		boolean showGroup = (negated || depth != 0) && children.size() > 0;
+
+		StringBuilder s = new StringBuilder(showGroup ? negated ? "!(" : "(" : "");
 		for (int i = 0; i < children.size(); i++) {
-			s.append(i != 0 ? " " + children.get(i).getOperator() + " " : "");
-			s.append(children.get(i).getType() == FilterType.GROUP ? ((GroupFilter) children.get(i)).toString(depth + 1) : children.get(i));
+			String child;
+			if (children.get(i).getType() == FilterType.GROUP) {
+				child = ((GroupFilter) children.get(i)).toString(depth + 1);
+			} else {
+				child = children.get(i).toString();
+			}
+			if (child.length() != 0) {
+				s.append(i != 0 ? " " + children.get(i).getOperator() + " " : "").append(child);
+			}
 		}
-		s.append(depth == 0 ? "" : ")");
+		s.append(showGroup ? ")" : "");
 		return s.toString();
 	}
 

--- a/src/main/java/net/querz/mcaselector/headless/FilterParser.java
+++ b/src/main/java/net/querz/mcaselector/headless/FilterParser.java
@@ -30,16 +30,27 @@ public class FilterParser {
 
 			ptr.skipWhitespace();
 
+			// parse negated group
+			boolean negated = false;
+			if (ptr.currentChar() == '!') {
+				negated = true;
+				ptr.next();
+				ptr.skipWhitespace();
+			}
+
 			// parse group
 			if (ptr.currentChar() == '(') {
 				ptr.next();
 				GroupFilter child = parse();
 				child.setOperator(operator);
 				group.addFilter(child);
+				group.setNegated(negated);
 				ptr.skipWhitespace();
 				ptr.expectChar(')');
 				ptr.skipWhitespace();
 				continue;
+			} else if (negated) {
+				throw ptr.parseException("only groups can be negated");
 			}
 
 			group.addFilter(parseFilterType(operator));

--- a/src/main/java/net/querz/mcaselector/headless/FilterParser.java
+++ b/src/main/java/net/querz/mcaselector/headless/FilterParser.java
@@ -43,8 +43,8 @@ public class FilterParser {
 				ptr.next();
 				GroupFilter child = parse();
 				child.setOperator(operator);
+				child.setNegated(negated);
 				group.addFilter(child);
-				group.setNegated(negated);
 				ptr.skipWhitespace();
 				ptr.expectChar(')');
 				ptr.skipWhitespace();
@@ -67,7 +67,7 @@ public class FilterParser {
 		FilterType t = FilterType.getByName(type);
 
 		if (t == null) {
-			throw ptr.parseException("invalid filter type");
+			throw ptr.parseException("invalid filter type \"" + type + "\"");
 		}
 
 		Comparator comparator = parseComparator();
@@ -134,12 +134,12 @@ public class FilterParser {
 
 	public static GroupFilter unwrap(GroupFilter filter) {
 		GroupFilter current = filter;
-		while (current.getFilterValue().size() == 1 && current.getFilterValue().get(0).getType() == FilterType.GROUP) {
+		while (current.getFilterValue().size() == 1 && current.getFilterValue().get(0).getType().getFormat() == FilterType.Format.GROUP) {
 			current = (GroupFilter) current.getFilterValue().get(0);
 		}
 
 		for (int i = 0; i < current.getFilterValue().size(); i++) {
-			if (current.getFilterValue().get(i).getType() == FilterType.GROUP) {
+			if (current.getFilterValue().get(i).getType().getFormat() == FilterType.Format.GROUP) {
 				current.getFilterValue().set(i, unwrap((GroupFilter) current.getFilterValue().get(i)));
 			}
 		}

--- a/src/main/java/net/querz/mcaselector/ui/GroupFilterBox.java
+++ b/src/main/java/net/querz/mcaselector/ui/GroupFilterBox.java
@@ -20,6 +20,7 @@ public class GroupFilterBox extends FilterBox {
 	}
 
 	private void setFilter(FilterBox parent, GroupFilter filter, boolean root) {
+		super.setFilter(filter);
 		filters.getChildren().clear();
 		add.setTooltip(UIFactory.tooltip(Translation.DIALOG_FILTER_CHUNKS_FILTER_ADD_TOOLTIP));
 		delete.setVisible(!root);
@@ -31,7 +32,11 @@ public class GroupFilterBox extends FilterBox {
 			getStyleClass().add("group-filter-box");
 		}
 
-		type.setDisable(!filter.getFilterValue().isEmpty() || root && parent == null);
+		if (!filter.getFilterValue().isEmpty() || root && parent == null) {
+			type.getItems().clear();
+			type.getItems().addAll(FilterType.GROUP, FilterType.NOT_GROUP);
+			type.getSelectionModel().select(filter.getType());
+		}
 
 		for (Filter<?> f : filter.getFilterValue()) {
 			if (f instanceof NumberFilter) {

--- a/src/main/java/net/querz/mcaselector/ui/dialog/FilterChunksDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/dialog/FilterChunksDialog.java
@@ -100,7 +100,7 @@ public class FilterChunksDialog extends Dialog<FilterChunksDialog.Result> {
 			try {
 				gf = fp.parse();
 				gf = FilterParser.unwrap(gf);
-				Debug.dumpf("parsed filter query from: %s, to: ", filterQuery.getText(), gf);
+				Debug.dumpf("parsed filter query from: %s, to: %s", filterQuery.getText(), gf);
 				value = gf;
 				groupFilterBox.setFilter(gf);
 			} catch (ParseException ex) {


### PR DESCRIPTION
Adds support for negated group filters.

A group filter can be negated by using the `Not Group` filter type in the filter UI, or when using headless or text mode by adding a `!` before a group's parentheses, e.g.: `!(xPos > 100 AND !(zPos < 100 OR zPos > 10))`

This also fixes a bug where changing a filter type would not keep the filter's value, operator and comparator if the filter types were compatible, e.g. when switching from an `xPos` filter type to a `zPos` filter type.