### PR TITLE
Add better edit options to the array editor

### DIFF
--- a/src/main/java/net/querz/mcaselector/ui/Window.java
+++ b/src/main/java/net/querz/mcaselector/ui/Window.java
@@ -7,9 +7,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import net.querz.mcaselector.tiles.TileMap;
 import net.querz.mcaselector.io.FileHelper;
-import net.querz.mcaselector.ui.dialog.EditArrayDialog;
 import net.querz.mcaselector.ui.dialog.PreviewDisclaimerDialog;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.*;
@@ -77,29 +75,6 @@ public class Window extends Application {
 		}
 
 		primaryStage.show();
-		long[] arr = new long[]{
-				0b1111_1110_1101_1100_1011_1010_1001_1000_0111_0110_0101_0100_0011_0010_0001_0000L,
-				0b0000_01011_01010_01001_01000_00111_00110_00101_00100_00011_00010_00001_00000L,
-				0b0000_001000_000111_000110_000110_000101_000100_000011_000010_000001_000000L,
-				0b0_0001000_0000111_0000110_0000101_0000100_0000011_0000010_0000001_0000000L,
-				0b00000111_00000110_00000101_00000100_00000011_00000010_00000001_00000000L,
-				0b0_000000110_000000101_000000100_000000011_000000010_000000001_000000000L,
-				0b0000_0000000101_0000000100_0000000011_0000000010_0000000001_0000000000L,
-				0b000000000_00000000100_00000000011_00000000010_00000000001_00000000000L,
-				0b0000_000000000100_000000000011_000000000010_000000000001_000000000000L,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-		};
-
-		EditArrayDialog<long[]> diag = new EditArrayDialog<>(arr, primaryStage);
-		diag.setResizable(true);
-		diag.showAndWait();
-
 	}
 
 	public void setTitleSuffix(String suffix) {

--- a/src/main/java/net/querz/mcaselector/ui/Window.java
+++ b/src/main/java/net/querz/mcaselector/ui/Window.java
@@ -7,6 +7,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import net.querz.mcaselector.tiles.TileMap;
 import net.querz.mcaselector.io.FileHelper;
+import net.querz.mcaselector.ui.dialog.EditArrayDialog;
 import net.querz.mcaselector.ui.dialog.PreviewDisclaimerDialog;
 
 import java.io.IOException;
@@ -76,6 +77,29 @@ public class Window extends Application {
 		}
 
 		primaryStage.show();
+		long[] arr = new long[]{
+				0b1111_1110_1101_1100_1011_1010_1001_1000_0111_0110_0101_0100_0011_0010_0001_0000L,
+				0b0000_01011_01010_01001_01000_00111_00110_00101_00100_00011_00010_00001_00000L,
+				0b0000_001000_000111_000110_000110_000101_000100_000011_000010_000001_000000L,
+				0b0_0001000_0000111_0000110_0000101_0000100_0000011_0000010_0000001_0000000L,
+				0b00000111_00000110_00000101_00000100_00000011_00000010_00000001_00000000L,
+				0b0_000000110_000000101_000000100_000000011_000000010_000000001_000000000L,
+				0b0000_0000000101_0000000100_0000000011_0000000010_0000000001_0000000000L,
+				0b000000000_00000000100_00000000011_00000000010_00000000001_00000000000L,
+				0b0000_000000000100_000000000011_000000000010_000000000001_000000000000L,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+		};
+
+		EditArrayDialog<long[]> diag = new EditArrayDialog<>(arr, primaryStage);
+		diag.setResizable(true);
+		diag.showAndWait();
+
 	}
 
 	public void setTitleSuffix(String suffix) {

--- a/src/main/java/net/querz/mcaselector/ui/dialog/EditArrayDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/dialog/EditArrayDialog.java
@@ -2,16 +2,20 @@ package net.querz.mcaselector.ui.dialog;
 
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.geometry.Pos;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
+import javafx.scene.control.Separator;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
@@ -33,9 +37,10 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 	private final ImageView addBefore, addAfter, add16Before, add16After, delete;
 	private boolean addMultiple = false;
 	private T array;
+	private short[] bitValues;
 
-	private CheckBox overlapping = new CheckBox();
-	private ComboBox<Integer> bits = new ComboBox<>();
+	private final CheckBox overlapping = new CheckBox();
+	private final ComboBox<BitCount> bits = new ComboBox<>();
 
 	@SuppressWarnings({"SuspiciousSystemArraycopy", "unchecked"})
 	public EditArrayDialog(T array, Stage primaryStage) {
@@ -48,12 +53,7 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 		getDialogPane().getStylesheets().addAll(primaryStage.getScene().getStylesheets());
 		getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
 
-		setResultConverter(b -> {
-			if (b == ButtonType.APPLY) {
-				return new Result(this.array);
-			}
-			return null;
-		});
+		setResultConverter(b -> b == ButtonType.APPLY ? new Result(this.array) : null);
 
 		table.setPlaceholder(new Label());
 		table.getStyleClass().add("array-editor-table-view");
@@ -130,34 +130,94 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 			}
 		});
 
+		getDialogPane().getScene().getWindow().sizeToScene();
+
+		((Stage) getDialogPane().getScene().getWindow()).setMinWidth(324);
+		((Stage) getDialogPane().getScene().getWindow()).setMinHeight(500);
+
 		addAfter.setOnMouseClicked(e -> add(addMultiple ? 16 : 1, true));
 		addBefore.setOnMouseClicked(e -> add(addMultiple ? 16 : 1, false));
 		delete.setOnMouseClicked(e -> delete());
 
-		bits.getItems().add(null);
-		for (int i = 4; i <= 12; i++) {
-			bits.getItems().add(i);
-		}
+		bits.getItems().addAll(BitCount.values());
+		bits.setPromptText("bits");
 
 		bits.valueProperty().addListener((v, o, n) -> {
+			if (n == null) {
+				// do nothing when clearing the selection, because we already are on BitCount.NONE
+				return;
+			} else if (n == BitCount.NONE) {
+				Platform.runLater(() -> bits.getSelectionModel().clearSelection());
+				addBefore.setDisable(false);
+				addAfter.setDisable(false);
+				overlapping.setDisable(true);
+			} else {
+				addBefore.setDisable(true);
+				addAfter.setDisable(true);
+				overlapping.setDisable(64 % n.bits == 0);
+			}
+			reloadBitValues(n);
 			table.getItems().clear();
 			applyArray();
 		});
 
-		// -----------------------------------------------
-		bits.getSelectionModel().select(new Integer(12));
-		// -----------------------------------------------
+		Label overlap = new Label("overlap:");
+		overlap.getStyleClass().add("overlap-label");
+
+		overlapping.selectedProperty().addListener((v, o, n) -> {
+			reloadBitValues(bits.getValue());
+			table.getItems().clear();
+			applyArray();
+		});
+
+		overlapping.setDisable(true);
 
 		HBox options = new HBox();
 		options.getStyleClass().add("array-editor-options");
-		options.getChildren().addAll(delete, addBefore, addAfter, overlapping, bits);
+		options.getChildren().addAll(delete, new Separator(), addBefore, addAfter, new Separator(), bits, new Separator(), overlap, overlapping);
 
-		VBox content = new VBox();
-		content.getChildren().addAll(table, options);
+		BorderPane content = new BorderPane();
+		BorderPane.setAlignment(table, Pos.TOP_LEFT);
+		content.setCenter(table);
+		content.setBottom(options);
 
 		applyArray();
 
 		getDialogPane().setContent(content);
+	}
+
+	private void reloadBitValues(BitCount bits) {
+		if (bits != BitCount.NONE) {
+			if (overlapping.isSelected()) {
+				long[] la = (long[]) array;
+				int bitValuesLength = (int) (64D / bits.bits * la.length);
+				bitValues = new short[bitValuesLength];
+				for (int i = 0; i < bitValuesLength; i++) {
+					double blockStatesIndex = i / ((double) bitValuesLength / la.length);
+					int longIndex = (int) blockStatesIndex;
+					int startBit = (int) ((blockStatesIndex - Math.floor(blockStatesIndex)) * 64D);
+					if (startBit + bits.bits > 64) {
+						long prev = Bits.bitRange(la[longIndex], startBit, 64);
+						long next = Bits.bitRange(la[longIndex + 1], 0, startBit + bits.bits - 64);
+						bitValues[i] = (short) ((next << 64 - startBit) + prev);
+					} else {
+						bitValues[i] = (short) Bits.bitRange(la[longIndex], startBit, startBit + bits.bits);
+					}
+				}
+			} else {
+				long[] la = (long[]) array;
+				int indicesPerLong = Math.floorDiv(64, bits.bits);
+				int bitValuesLength = la.length * indicesPerLong;
+				bitValues = new short[bitValuesLength];
+				for (int i = 0; i < bitValuesLength; i++) {
+					int blockStatesIndex = i / indicesPerLong;
+					int startBit = (i % indicesPerLong) * bits.bits;
+					bitValues[i] = (short) Bits.bitRange(la[blockStatesIndex], startBit, startBit + bits.bits);
+				}
+			}
+		} else {
+			bitValues = null;
+		}
 	}
 
 	private Label createAddRowLabel(String styleClass, ImageView icon, ImageView altIcon) {
@@ -244,8 +304,8 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 				public Long fromString(String s) {
 					try {
 						long l = super.fromString(s);
-						if (bits.getValue() != null) {
-							int max = (int) Math.pow(2, bits.getValue());
+						if (bits.getValue() != BitCount.NONE) {
+							int max = (int) Math.pow(2, bits.getValue().bits);
 							if (l < max && l >= 0) {
 								return l;
 							} else {
@@ -295,34 +355,41 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 			}
 		} else if (array instanceof long[]) {
 			long[] la = (long[]) array;
-			if (bits.getValue() == null) {
+			if (bits.getValue() == BitCount.NONE || bits.getValue() == null) {
 				for (int i = 0; i < la.length; i++) {
 					table.getItems().add(new Row(i, la[i]));
 				}
 			} else {
-				int length = Math.floorDiv(64, bits.getValue()) * la.length;
-				for (int i = 0; i < length; i++) {
-					if (bits.getValue() != null) {
-						int bits = this.bits.getValue();
-						int indicesPerLong = (int) (64D / bits);
-						int blockStatesIndex = i / indicesPerLong;
-						int startBit = (i % indicesPerLong) * bits;
-						int value = (int) Bits.bitRange(la[blockStatesIndex], startBit, startBit + bits);
-						table.getItems().add(new Row(i, value));
-					}
+				for (int i = 0; i < bitValues.length; i++) {
+					table.getItems().add(new Row(i, bitValues[i]));
 				}
 			}
 		}
 	}
 
 	private <V extends Number> void updateArrayIndex(int index, V value) {
-		if (array instanceof long[] && bits.getValue() != null) {
-			long[] l = (long[]) array;
-			int bits = this.bits.getValue();
-			int indicesPerLong = (int) (64D / bits);
-			int blockStatesIndex = index / indicesPerLong;
-			int startBit = (index % indicesPerLong) * bits;
-			l[blockStatesIndex] = Bits.setBits(value.longValue(), l[blockStatesIndex], startBit, startBit + bits);
+		if (array instanceof long[] && bits.getValue() != BitCount.NONE) {
+			if (overlapping.isSelected()) {
+				long[] l = (long[]) array;
+				int bits = this.bits.getValue().bits;
+				double blockStatesIndex = index / ((double) bitValues.length / l.length);
+				int longIndex = (int) blockStatesIndex;
+				int startBit = (int) ((blockStatesIndex - Math.floor(longIndex)) * 64D);
+				if (startBit + bits > 64) {
+					l[longIndex] = Bits.setBits(value.shortValue(), l[longIndex], startBit, 64);
+					l[longIndex + 1] = Bits.setBits(value.shortValue(), l[longIndex + 1], startBit - 64, startBit + bits - 64);
+				} else {
+					l[longIndex] = Bits.setBits(value.shortValue(), l[longIndex], startBit, startBit + bits);
+				}
+			} else {
+				long[] l = (long[]) array;
+				int bits = this.bits.getValue().bits;
+				int indicesPerLong = (int) (64D / bits);
+				int blockStatesIndex = index / indicesPerLong;
+				int startBit = (index % indicesPerLong) * bits;
+				l[blockStatesIndex] = Bits.setBits(value.longValue(), l[blockStatesIndex], startBit, startBit + bits);
+			}
+			bitValues[index] = value.shortValue();
 		} else {
 			Array.set(array, index, value);
 		}
@@ -357,6 +424,7 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 		if (selected == -1) {
 			selected = after ? table.getItems().size() : 0;
 		}
+
 		for (int i = 0; i < amount; i++) {
 			newRows.add(new Row(i + selected + a, 0));
 		}
@@ -400,6 +468,36 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 		void setValue(V value) {
 			this.value = value;
 			updateArrayIndex(index, value);
+		}
+	}
+
+	private enum BitCount {
+		NONE(-1, ""),
+		FOUR(4),
+		FIVE(5),
+		SIX(6),
+		SEVEN(7),
+		EIGHT(8),
+		NINE(9),
+		TEN(10),
+		ELEVEN(11),
+		TWELVE(12);
+
+		int bits;
+		String string;
+
+		BitCount(int bits) {
+			this(bits, "" + bits);
+		}
+
+		BitCount(int bits, String string) {
+			this.bits = bits;
+			this.string = string;
+		}
+
+		@Override
+		public String toString() {
+			return string;
 		}
 	}
 }

--- a/src/main/java/net/querz/mcaselector/ui/dialog/EditArrayDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/dialog/EditArrayDialog.java
@@ -151,10 +151,12 @@ public class EditArrayDialog<T> extends Dialog<EditArrayDialog.Result> {
 				addBefore.setDisable(false);
 				addAfter.setDisable(false);
 				overlapping.setDisable(true);
+				delete.setDisable(false);
 			} else {
 				addBefore.setDisable(true);
 				addAfter.setDisable(true);
 				overlapping.setDisable(64 % n.bits == 0);
+				delete.setDisable(true);
 			}
 			reloadBitValues(n);
 			table.getItems().clear();

--- a/src/main/resources/style.css
+++ b/src/main/resources/style.css
@@ -1012,19 +1012,41 @@
 }
 
 .array-editor-add-tag-label {
-	-fx-padding: 3 0 3 0;
+	-fx-padding: 3 2 3 2;
 }
 
 .array-editor-add-tag-label:hover {
-	-fx-padding: 2 -1 2 -1;
+	-fx-padding: 2 1 2 1;
 }
 
 .array-editor-delete-tag-label {
-	-fx-border-width: 0 2 0 0;
-	-fx-padding: 0 2 0 0;
-	-fx-border-color: -color-dialog-separator;
+	-fx-padding: 3 0 0 2;
 }
 
 .array-editor-delete-tag-label-enabled:hover {
-	-fx-padding: -1 1 -1 -1;
+	-fx-padding: 2 -1 -1 1;
+}
+
+.array-editor-options .separator {
+	-fx-orientation: vertical;
+	-fx-padding: 2 10 2 10;
+	-fx-background-color: transparent;
+}
+
+.array-editor-options .separator *.line {
+	-fx-border-width: 0;
+	-fx-width: 2;
+	-fx-background-color: -color-menu-separator;
+}
+
+.array-editor-options .combo-box {
+	-fx-pref-width: 50;
+}
+
+.array-editor-options .overlap-label {
+	-fx-padding: 2 0 0 0;
+}
+
+.array-editor-options .check-box {
+	-fx-padding: -1 0 0 -1;
 }


### PR DESCRIPTION
Adding 2 options to the array editor when editing *long* arrays:

* A dropdown to select the bits-per-long to make editing the BlockStates array easier
* A checkbox to enable / disable overlapping (e.g. if "5" bits are selected, a long can hold 12 5-bit values and the last 4 bits will then be ignored when this checkbox is not selected. When it is selected, it will display those 4 bits + the first bit from the next long value as one 5-bit value)

When editing values while having bits selected, adding and deleting values is disabled.