### PR TITLE
update pt_BR translation

### DIFF
--- a/src/main/resources/lang/pt_BR.txt
+++ b/src/main/resources/lang/pt_BR.txt
@@ -16,8 +16,8 @@ menu.view;Visão
 menu.selection;Seleção
 menu.tools;Ferramentas
 menu.about;Sobre
-menu.file.open_world;Abra um mundo
-menu.file.open;Abra uma região
+menu.file.open_world;Abrir mundo
+menu.file.open;Abrir região
 menu.file.settings;Configuração
 menu.file.world_settings;Configurações do mundo
 menu.file.quit;Sair
@@ -28,8 +28,8 @@ menu.view.reset_zoom;Redefinir zoom
 menu.view.save_screenshot;Salvar captura de tela
 menu.view.clear_cache;Limpar cache
 menu.view.clear_all_cache;Limpar todo o cache
-menu.selection.clear;Deselecionar tudo
-menu.selection.invert;Invertida
+menu.selection.clear;Limpar
+menu.selection.invert;Inverter
 menu.selection.copy_chunks;Copiar chunks
 menu.selection.paste_chunks;Colar chunks
 menu.selection.export_chunks;Exportar chunks selecionados
@@ -48,56 +48,56 @@ menu.tools.next_overlay;Próxima sobreposição
 dialog.select_world.title;Selecione uma dimensão
 dialog.settings.title;Configuração
 dialog.settings.language;Idioma
-dialog.settings.read_threads;Ler threads
-dialog.settings.process_threads;Procesar threads
-dialog.settings.write_threads;Escrever threads
-dialog.settings.max_files;Carga máxima de arquivos
-dialog.settings.region_color;Cor das regiões
-dialog.settings.chunk_color;Cor dos chunks
+dialog.settings.read_threads;Threads de leitura
+dialog.settings.process_threads;Threads de processamento
+dialog.settings.write_threads;Threads de escrita
+dialog.settings.max_files;Número máximo de arquivos
+dialog.settings.region_color;Cor das regiões selecionadas
+dialog.settings.chunk_color;Cor dos chunks selecionados
 dialog.settings.pasted_chunks_color;Cor dos chunks inseridos
 dialog.settings.shade;Sombra
 dialog.settings.shade_water;Profundidade da água
-dialog.settings.mc_saves_dir;Diretório Minecraft
+dialog.settings.mc_saves_dir;Diretório de mundos do Minecraft
 dialog.settings.print_debug;Mostrar mensagens de desenvolvedor
 dialog.settings.show_log_file;Mostrar arquivo de log
 dialog.settings.reset;Resetar
-dialog.world_settings.title;Configurações mundiais
+dialog.world_settings.title;Configurações do mundo
 dialog.world_settings.poi;POI
 dialog.world_settings.entities;Entidades
 dialog.goto.title;Ir para coordenadas
 dialog.confirmation.question;Tem certeza?
 dialog.delete_chunks_confirmation.title;Apagar chunks
-dialog.delete_chunks_confirmation.header_short;Você está prestes a remover um número desconhecido de chunks deste mundo.
-dialog.delete_chunks_confirmation.header_verbose;Serão removidos %d chunks deste mundo.
+dialog.delete_chunks_confirmation.header_short;Você está prestes a remover um número desconhecido de chunks desse mundo.
+dialog.delete_chunks_confirmation.header_verbose;Serão removidos %d chunks desse mundo.
 dialog.image_export_confirmation.title;Exportar imagem
 dialog.image_export_confirmation.header_short;Você está prestes a criar uma imagem de proporções desconhecidas.
 dialog.image_export_confirmation.header_verbose;Você está prestes a criar uma imagem com as dimensões %dx%d.
 dialog.import_chunks_confirmation.title;Importar chunks
 dialog.import_chunks_confirmation.header;Você está prestes a importar um número desconhecido de chunks neste mundo.
 dialog.import_chunks_confirmation.options;Opções
-dialog.import_chunks_confirmation.options.offset;Offset
+dialog.import_chunks_confirmation.options.offset;Descolamento
 dialog.import_chunks_confirmation.options.overwrite;Sobrescrever chunks existentes
 dialog.import_chunks_confirmation.options.selection_only;Aplicar somente na seleção.
 dialog.import_chunks_confirmation.options.sections;Seções
 dialog.import_chunks_confirmation.warning;Advertencia:A importação de chunks deslocados no espaço não atualizará as coordenadas dos blocos de comandos.
 dialog.export_chunks_confirmation.title;Exportar chunks
-dialog.export_chunks_confirmation.header_short;Você está prestes a exportar um número desconhecido de Chunks deste mundo.
-dialog.export_chunks_confirmation.header_verbose;Serão exportados %d chunks deste mundo.
+dialog.export_chunks_confirmation.header_short;Você está prestes a exportar um número desconhecido de Chunks desse mundo.
+dialog.export_chunks_confirmation.header_verbose;Serão exportados %d chunks desse mundo.
 dialog.filter_chunks.title;Filtrar chunks
-dialog.filter_chunks.filter.add.tooltip;Adicionar nova condição sobre esta.
-dialog.filter_chunks.filter.delete.tooltip;Apagar esta condição.
-dialog.filter_chunks.filter.type.tooltip;Tipo de condição.
+dialog.filter_chunks.filter.add.tooltip;Adicionar nova condição sobre essa.
+dialog.filter_chunks.filter.delete.tooltip;Apagar essa condição.
+dialog.filter_chunks.filter.type.tooltip;Tipo dessa condição.
 dialog.filter_chunks.filter.operator.tooltip;Operador para vincular múltiplas condições.
 dialog.filter_chunks.filter.comparator.tooltip;Comparador.
 dialog.filter_chunks.select;Seleção
 dialog.filter_chunks.select.tooltip;Cria uma seleção de todos os chunks afetados.
 dialog.filter_chunks.export;Exportar
-dialog.filter_chunks.export.tooltip;Exporta todos os chunks afetados a una nova pasta.
+dialog.filter_chunks.export.tooltip;Exporta todos os chunks afetados a uma nova pasta.
 dialog.filter_chunks.delete;Apagar
 dialog.filter_chunks.delete.tooltip;Apaga todos os chunks afetados do mundo atual.
 dialog.filter_chunks.selection_only;Aplicar somente na seleção.
 dialog.filter_chunks.selection_radius;Raio de seleção
-dialog.filter_chunks.selection_only.tooltip;Este filtro se aplica apenas na seleção atual.
+dialog.filter_chunks.selection_only.tooltip;Se esse filtro se aplica apenas na seleção atual.
 dialog.edit_overlays.title;Editar sobreposições
 dialog.edit_overlays.overlay_active.tooltip;Ativo
 dialog.edit_overlays.delete.tooltip;Excluir
@@ -107,18 +107,18 @@ dialog.change_nbt.change.tooltip;Altera o valor apenas se sua chave existir.
 dialog.change_nbt.force;Forçar
 dialog.change_nbt.force.tooltip;Criar tag caso não exista.
 dialog.change_nbt.selection_only;Aplicar somente na seleção.
-dialog.change_nbt.selection_only.tooltip;Este filtro aplica-se apenas à seleção atual.
+dialog.change_nbt.selection_only.tooltip;Se esse filtro aplica-se apenas à seleção atual.
 dialog.change_nbt_confirmation.title;Alterar NBT
-dialog.change_nbt_confirmation.header_short;Serão alterados os dados em um número desconhecido de chunks deste mundo.
-dialog.change_nbt_confirmation.header_verbose;Serão alterados os dados em %d chunks deste mundo.
+dialog.change_nbt_confirmation.header_short;Serão alterados os dados em um número desconhecido de chunks desse mundo.
+dialog.change_nbt_confirmation.header_verbose;Serão alterados os dados em %d chunks desse mundo.
 dialog.edit_nbt.title;Editar chunk
 dialog.edit_nbt.placeholder.loading;carregando...
 dialog.edit_nbt.placeholder.no_chunk_data;nenhum dado de bloco chunk
-dialog.edit_nbt.placeholder.no_region_file;region file does not exist
+dialog.edit_nbt.placeholder.no_region_file;arquivo de região não existe
 dialog.edit_array.index;Índice
 dialog.edit_array.value;Valor
 dialog.about.title;Sobre
-dialog.about.header;Sobre o Seletor de MCA
+dialog.about.header;Sobre o MCA Selector
 dialog.about.version;Versão:
 dialog.about.version.unknown;Desconhecido
 dialog.about.version.check;Analizar
@@ -132,7 +132,7 @@ dialog.progress.title;Progresso
 dialog.progress.no_files;Não há arquivos
 dialog.progress.running;Executando...
 dialog.progress.cancelling;Cancelando...
-dialog.progress.collecting_data;Recopilando dados...
+dialog.progress.collecting_data;Coletando dados...
 dialog.progress.done;Concluido.
 dialog.progress.title.deleting_selection;Apagando seleção...
 dialog.progress.title.creating_image;Criando imagem...


### PR DESCRIPTION
Minor changes to pt_BR translation:

1. Typo on line 95 (The same typo is on pt_PT but I didn't check all the translation carefully yet)
2. [Anáfora x Catáfora](https://educacao.uol.com.br/disciplinas/portugues/este-esta-isto-esse-essa-isso-pronomes-demonstrativos-deixis-anafora-e-catafora.htm)
3. Infinitive verbs to match the pattern

Loved this project @Querz , hope you can keep going!