### PR TITLE
Inno / CLI bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,17 +100,18 @@ task installer {
 		// assemble license file
 		String finalLicense = new String(Files.readAllBytes(new File("${rootProject.projectDir}/LICENSE").toPath()))
 		finalLicense += "\n\n\n" +
-				"##########################################################################################\n" +
-				"##########################################################################################\n" +
-				"##                                                                                      ##\n" +
-				"##                                  3RD PARTY LICENSES                                  ##\n" +
-				"##                                                                                      ##\n" +
-				"##########################################################################################\n" +
-				"##########################################################################################"
+				"############################################################\n" +
+				"############################################################\n" +
+				"##                                                        ##\n" +
+				"##                   3RD PARTY LICENSES                   ##\n" +
+				"##                                                        ##\n" +
+				"############################################################\n" +
+				"############################################################"
 		for (File file : new File("${rootProject.projectDir}/src/main/resources/licenses").listFiles()) {
 			finalLicense = appendLicense(file, finalLicense)
 		}
 		finalLicense = appendLicense(new File("${rootProject.projectDir}/travis/winrun4j/winrun4j.license.txt"), finalLicense)
+		finalLicense = appendLicense(new File("${rootProject.projectDir}/src/main/resources/font/notosans-regular.license.txt"), finalLicense)
 		Files.write(new File(innoSetupDir, "LICENSE").toPath(), finalLicense.getBytes(StandardCharsets.UTF_8))
 
 		copy {
@@ -249,8 +250,7 @@ static String createTOC(String f, String st, String en, boolean it, boolean is) 
 		for (String n in br.lines()) {
 			String t
 			if ((t = n.trim()).startsWith('#')) {
-				for (l = 0; l < t.length() && t.charAt(l) == '#' as char; l++) {/**/
-				}
+				for (l = 0; l < t.length() && t.charAt(l) == '#' as char; l++) {/**/}
 				s += l == 4 ? 1 : 0
 				if (t.length() == l || t.charAt(l) != ' ' as char || it && l == 1 || is && l == 4 && s == 1)
 					continue
@@ -270,11 +270,10 @@ static String createTOC(String f, String st, String en, boolean it, boolean is) 
 static String pad(String s, char p, int l) {
 	StringBuilder sb = new StringBuilder(s)
 	for (int i = s.length(); i < l; i++) {
-		if (i % 2 == 1) {
+		if (i % 2 == 1)
 			sb.append(p)
-		} else {
+		else
 			sb.insert(0, p)
-		}
 	}
 	return sb.toString()
 }
@@ -284,16 +283,9 @@ static String appendLicense(File f, String l) {
 	if (f.getName().endsWith(".license.txt")) {
 		String licenseName = f.getName().replace(".license.txt", "").toUpperCase()
 		l += "\n\n\n" +
-				"##########################################################################################\n" +
-				"#" + pad(" License for " + licenseName, ' ' as char, 88) + "#\n" +
-				"##########################################################################################\n\n" +
-				content
-	} else if (f.getName().endsWith(".notice.txt")) {
-		String noticeName = f.getName().replace(".notice.txt", "").toUpperCase()
-		l += "\n\n\n" +
-				"##########################################################################################\n" +
-				"#" + pad("Notice for " + noticeName, ' ' as char, 88) + "#\n" +
-				"##########################################################################################\n\n" +
+				"############################################################\n" +
+				"#" + pad(" License for " + licenseName, ' ' as char, 58) + "#\n" +
+				"############################################################\n\n" +
 				content
 	}
 	return l

--- a/build.gradle
+++ b/build.gradle
@@ -102,9 +102,9 @@ task installer {
 		finalLicense += "\n\n\n" +
 				"############################################################\n" +
 				"############################################################\n" +
-				"##                                                        ##\n" +
-				"##                   3RD PARTY LICENSES                   ##\n" +
-				"##                                                        ##\n" +
+				"##\n" +
+				"##                   3RD PARTY LICENSES\n" +
+				"##\n" +
 				"############################################################\n" +
 				"############################################################"
 		for (File file : new File("${rootProject.projectDir}/src/main/resources/licenses").listFiles()) {
@@ -268,14 +268,10 @@ static String createTOC(String f, String st, String en, boolean it, boolean is) 
 }
 
 static String pad(String s, char p, int l) {
-	StringBuilder sb = new StringBuilder(s)
-	for (int i = s.length(); i < l; i++) {
-		if (i % 2 == 1)
-			sb.append(p)
-		else
-			sb.insert(0, p)
-	}
-	return sb.toString()
+	StringBuilder sb = new StringBuilder(l)
+	for (int i = 0; i < l - s.length(); i += 2)
+		sb.append(p)
+	return sb.append(s).toString()
 }
 
 static String appendLicense(File f, String l) {
@@ -284,7 +280,7 @@ static String appendLicense(File f, String l) {
 		String licenseName = f.getName().replace(".license.txt", "").toUpperCase()
 		l += "\n\n\n" +
 				"############################################################\n" +
-				"#" + pad(" License for " + licenseName, ' ' as char, 58) + "#\n" +
+				"#" + pad("License for " + licenseName, ' ' as char, 58) + "\n" +
 				"############################################################\n\n" +
 				content
 	}

--- a/inno/inno.iss
+++ b/inno/inno.iss
@@ -48,6 +48,7 @@ Type: filesandordirs; Name: "{app}\\jre"
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}\\jre"
+Type: filesandordirs; Name: "{app}\\zulu8.52.0.23-ca-fx-jre8.0.282-win_x64"
 
 [Icons]
 Name: "{autoprograms}\\${applicationName}"; Filename: "{app}\\${applicationName}.exe"
@@ -101,6 +102,4 @@ begin
 		Log('Failed to rename jre folder, creating custom ini');
 		SaveStringToFile(ExpandConstant('{app}\\MCA Selector.ini'), 'vm.location=zulu8.52.0.23-ca-fx-jre8.0.282-win_x64\\bin\\server\\jvm.dll', False);
 	end;
-
-	SaveStringToFile(ExpandConstant('{app}\\testing.ini'), 'vm.location=zulu8.52.0.23-ca-fx-jre8.0.282-win_x64\\bin\\server\\jvm.dll', False);
 end;

--- a/inno/inno.iss
+++ b/inno/inno.iss
@@ -97,5 +97,10 @@ end;
 procedure RenameJRE;
 begin
 	Log('Renaming jre directory');
-	RenameFile(ExpandConstant('{app}\\zulu8.52.0.23-ca-fx-jre8.0.282-win_x64'), ExpandConstant('{app}\\jre'));
+	if not RenameFile(ExpandConstant('{app}\\zulu8.52.0.23-ca-fx-jre8.0.282-win_x64'), ExpandConstant('{app}\\jre')) then begin
+		Log('Failed to rename jre folder, creating custom ini');
+		SaveStringToFile(ExpandConstant('{app}\\MCA Selector.ini'), 'vm.location=zulu8.52.0.23-ca-fx-jre8.0.282-win_x64\\bin\\server\\jvm.dll', False);
+	end;
+
+	SaveStringToFile(ExpandConstant('{app}\\testing.ini'), 'vm.location=zulu8.52.0.23-ca-fx-jre8.0.282-win_x64\\bin\\server\\jvm.dll', False);
 end;

--- a/inno/inno.iss
+++ b/inno/inno.iss
@@ -49,6 +49,7 @@ Type: filesandordirs; Name: "{app}\\jre"
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}\\jre"
 Type: filesandordirs; Name: "{app}\\zulu8.52.0.23-ca-fx-jre8.0.282-win_x64"
+Type: filesandordirs; Name: "{app}\\MCA Selector.ini"
 
 [Icons]
 Name: "{autoprograms}\\${applicationName}"; Filename: "{app}\\${applicationName}.exe"

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -176,10 +176,16 @@ public final class Config {
 	}
 
 	public static File getCacheDirForWorldUUID(UUID world, int zoomLevel) {
+		if (world == null) {
+			return new File(cacheDir, "" + zoomLevel);
+		}
 		return new File(baseCacheDir, world.toString().replace("-", "") + "/" + zoomLevel);
 	}
 
 	public static File getCacheDirForWorldUUID(UUID world) {
+		if (world == null) {
+			return cacheDir;
+		}
 		return new File(baseCacheDir, world.toString().replace("-", ""));
 	}
 

--- a/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/headless/ParamExecutor.java
@@ -493,11 +493,11 @@ public final class ParamExecutor {
 			throw new ParseException("missing " + key + " directory");
 		}
 		File file = new File(f);
-		if (!file.isDirectory()) {
-			throw new ParseException(file + " is not a directory");
-		}
 		if (!file.exists() && !file.mkdirs()) {
 			throw new IOException("failed to create directory " + file);
+		}
+		if (!file.isDirectory()) {
+			throw new ParseException(file + " is not a directory");
 		}
 		return file;
 	}

--- a/src/main/java/net/querz/mcaselector/io/CacheHelper.java
+++ b/src/main/java/net/querz/mcaselector/io/CacheHelper.java
@@ -7,7 +7,6 @@ import net.querz.mcaselector.tiles.Tile;
 import net.querz.mcaselector.tiles.TileMap;
 import net.querz.mcaselector.debug.Debug;
 import net.querz.mcaselector.progress.Progress;
-import net.querz.mcaselector.tiles.overlay.OverlayType;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/main/java/net/querz/mcaselector/io/MCAFilePipe.java
+++ b/src/main/java/net/querz/mcaselector/io/MCAFilePipe.java
@@ -7,10 +7,9 @@ import net.querz.mcaselector.io.job.ParseDataJob;
 import net.querz.mcaselector.io.job.ProcessDataJob;
 import net.querz.mcaselector.io.job.SaveDataJob;
 import net.querz.mcaselector.validation.ShutdownHooks;
-
-import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -57,22 +56,26 @@ public final class MCAFilePipe {
 		loadDataExecutor = new ThreadPoolExecutor(
 				Config.getLoadThreads(), Config.getLoadThreads(),
 				0L, TimeUnit.MILLISECONDS,
-				new LinkedBlockingQueue<>());
+				new LinkedBlockingQueue<>(),
+				new NamedThreadFactory("loadPool"));
 		Debug.dumpf("created data load ThreadPoolExecutor with %d threads", Config.getLoadThreads());
 		processDataExecutor = new ThreadPoolExecutor(
 				Config.getProcessThreads(), Config.getProcessThreads(),
 				0L, TimeUnit.MILLISECONDS,
-				new LinkedBlockingQueue<>());
+				new LinkedBlockingQueue<>(),
+				new NamedThreadFactory("processPool"));
 		Debug.dumpf("created data processor ThreadPoolExecutor with %d threads", Config.getProcessThreads());
 		saveDataExecutor = new ThreadPoolExecutor(
 				Config.getWriteThreads(), Config.getWriteThreads(),
 				0L, TimeUnit.MILLISECONDS,
-				new LinkedBlockingQueue<>());
+				new LinkedBlockingQueue<>(),
+				new NamedThreadFactory("savePool"));
 		Debug.dumpf("created data save ThreadPoolExecutor with %d threads", Config.getWriteThreads());
 		dataParsingExecutor = new ThreadPoolExecutor(
 				1, 1,
 				0L, TimeUnit.MILLISECONDS,
-				new LinkedBlockingQueue<>());
+				new LinkedBlockingQueue<>(),
+				new NamedThreadFactory("parsePool"));
 		Debug.dumpf("created data parser ThreadPoolExecutor with %d threads", 1);
 	}
 

--- a/src/main/java/net/querz/mcaselector/io/NamedThreadFactory.java
+++ b/src/main/java/net/querz/mcaselector/io/NamedThreadFactory.java
@@ -1,0 +1,18 @@
+package net.querz.mcaselector.io;
+
+import java.util.concurrent.ThreadFactory;
+
+public class NamedThreadFactory implements ThreadFactory {
+
+	private String name;
+	private int count;
+
+	public NamedThreadFactory(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public Thread newThread(Runnable r) {
+		return new Thread(r, name + "-thread-" + count++);
+	}
+}

--- a/src/main/java/net/querz/mcaselector/tiles/OverlayPool.java
+++ b/src/main/java/net/querz/mcaselector/tiles/OverlayPool.java
@@ -8,6 +8,7 @@ import net.querz.mcaselector.Config;
 import net.querz.mcaselector.debug.Debug;
 import net.querz.mcaselector.io.FileHelper;
 import net.querz.mcaselector.io.MCAFilePipe;
+import net.querz.mcaselector.io.NamedThreadFactory;
 import net.querz.mcaselector.io.db.CacheDBController;
 import net.querz.mcaselector.io.job.ParseDataJob;
 import net.querz.mcaselector.point.Point2i;
@@ -33,13 +34,15 @@ public class OverlayPool {
 	private final ThreadPoolExecutor overlayCacheLoaders = new ThreadPoolExecutor(
 			4, 4,
 			0L, TimeUnit.MILLISECONDS,
-			new LinkedBlockingQueue<>());
+			new LinkedBlockingQueue<>(),
+			new NamedThreadFactory("overlayCachePool"));
 
 	// used to load region data from db asynchronously to be displayed in the status bar
 	private final ThreadPoolExecutor overlayValueLoader = new ThreadPoolExecutor(
 			1, 1,
 			0L, TimeUnit.MILLISECONDS,
-			new LinkedBlockingQueue<>());
+			new LinkedBlockingQueue<>(),
+			new NamedThreadFactory("overlayValuePool"));
 
 	private final CacheDBController dataCache = new CacheDBController();
 	private OverlayParser parser;

--- a/src/main/resources/font/notosans-regular.license.txt
+++ b/src/main/resources/font/notosans-regular.license.txt
@@ -1,3 +1,4 @@
+Copyright 2012 Google Inc. All Rights Reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -175,28 +176,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/src/main/resources/licenses/ar.com.hjg.pngj.license.txt
+++ b/src/main/resources/licenses/ar.com.hjg.pngj.license.txt
@@ -1,3 +1,13 @@
+PNGJ : PNG image IO Java library
+Copyright 2009-2012 Hernán J. González
+
+This product includes software developed by:
+Hernán J. González
+(Buenos Aires, Argentina)
+hgonzalez@gmail.com
+http://hjg.com.ar/
+http://stackexchange.com/users/103559/leonbloy
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -174,28 +184,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/src/main/resources/licenses/ar.com.hjg.pngj.notice.txt
+++ b/src/main/resources/licenses/ar.com.hjg.pngj.notice.txt
@@ -1,9 +1,0 @@
-﻿PNGJ : PNG image IO Java library
-Copyright 2009-2012 Hernán J. González
-
-This product includes software developed by: 
-Hernán J. González  
-(Buenos Aires, Argentina) 
-hgonzalez@gmail.com  
-http://hjg.com.ar/  
-http://stackexchange.com/users/103559/leonbloy

--- a/src/main/resources/licenses/org.xerial.sqlite-jdbc.license.txt
+++ b/src/main/resources/licenses/org.xerial.sqlite-jdbc.license.txt
@@ -1,3 +1,31 @@
+This product includes the following softwares developed by David Crawshaw:
+
+Copyright (c) 2006, David Crawshaw.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+And also, NestedVM (Apache License Version 2.0) is used inside sqlite-
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -174,28 +202,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.


### PR DESCRIPTION
* Inno Setup will now create a custom `MCA Selector.ini` file when it fails to rename the jre folder, pointing to the unrenamed folder.
* Fixed license titles looking broken in Inno Setup
* Gave names to all significant threads for easier debugging
* Fixed a bug where generating cache images in CLI would throw exceptions