### PR TITLE
Modified zulu JRE-FX installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,11 +479,11 @@ For Windows:
 
 * Download the JRE-FX-16 from [HERE](https://cdn.azul.com/zulu/bin/zulu16.30.15-ca-fx-jre16.0.1-win_x64.zip) into an 
   empty folder.
-* Move the previously downloaded `mcaselector-1.16.2.jar` into the same folder. Extract the content of the 
+* Move the previously downloaded `mcaselector.jar` into the same folder. Extract the content of the 
   downloaded .zip file into this folder.
 * Hold `Shift` and `right-click` an empty spot in this folder, and choose `Open PowerShell window here`. Type `& ` 
   (with a space at the end), go into the previously extracted folder and drag and drop the `bin\java.exe` file into 
-  the PowerShell window. Then complete the command by typing a space and ` -jar mcaselector-1.16.2.jar` and press 
+  the PowerShell window. Then complete the command by typing ` -jar ` (with a space both at the beginning and the end), then dragging and dropping the `mcaselector.jar` file and pressing 
   `Enter`.
 
 For MacOS:


### PR DESCRIPTION
Modified documentation for the "Download and installation" section under the "With zulu JRE-FX:" subsection. The jar file is no longer named mcaselector-1.16.2.jar so following the original directions yields a "Unable to access jarfile mcaselector-1.16.2.jar" error. The jar file downloaded is named mcaselector.jar and having users drag and drop will be easier for the future.