### PR TITLE
Handle missing cache version file for new worlds

### DIFF
--- a/src/main/java/net/querz/mcaselector/io/CacheHelper.java
+++ b/src/main/java/net/querz/mcaselector/io/CacheHelper.java
@@ -151,8 +151,12 @@ public final class CacheHelper {
 		}
 
 		File cacheVersionFile = new File(Config.getCacheDir(), "version");
-
-		String version = readVersionFromFile(cacheVersionFile);
+		String version = null;
+		if(cacheVersionFile.exists()) {
+			version = readVersionFromFile(cacheVersionFile);
+		} else {
+			Debug.dump("no cache found for this world");
+		}
 		if (!applicationVersion.equals(version)) {
 			clearAllCache(tileMap);
 		}


### PR DESCRIPTION
When a world is loaded for the first time, the belonging cache directory does not exist yet. Therefore when trying to read the cache version file, a FileNotFoundException is thrown and dumped into the log/stdout.

This PR adds a check for the existence of such a version file, before reading it. The resulting behavior stays the same for both cases  (existence and non-existance), only the error handing is cleaner (IMHO).