### PR TITLE
Improvements to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import java.nio.file.Files
 
 plugins {
 	id 'java'
+	id 'org.openjfx.javafxplugin' version '0.0.10'
 	id 'application'
 
 	id 'com.github.johnrengelman.shadow' version '7.1.1'
@@ -19,6 +20,11 @@ def appUrl = 'https://github.com/Querz/mcaselector'
 def appAuthor = 'Querz'
 
 sourceCompatibility = 17
+
+javafx {
+	version = "$sourceCompatibility"
+	modules = ['javafx.controls', 'javafx.swing']
+}
 
 application {
 	mainClass = 'net.querz.mcaselector.Main'

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,11 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 plugins {
-	id "com.github.johnrengelman.shadow" version "7.0.0"
 	id 'java'
+	id 'application'
+
+	id 'com.github.johnrengelman.shadow' version '7.0.0'
+
 	id 'eclipse'
 	id 'idea'
 }
@@ -16,7 +19,12 @@ def appAuthor = 'Querz'
 
 sourceCompatibility = 17
 
+application {
+	mainClass = 'net.querz.mcaselector.Main'
+}
+
 idea {
+	module.downloadJavadoc = true
 	module.downloadSources = true
 }
 
@@ -49,7 +57,7 @@ task copyRuntimeLibs(type: Copy) {
 jar {
 	archiveFileName = "${project.name}-${project.version}-min.jar"
 	manifest.attributes (
-		'Main-Class': 'net.querz.mcaselector.Main',
+		'Main-Class': application.mainClass,
 		'Application-Version': project.version,
 		'Class-Path': configurations.implementation.files.collect{"lib/$it.name"}.join(' ')
 	)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ plugins {
 	id 'java'
 	id 'application'
 
-	id 'com.github.johnrengelman.shadow' version '7.0.0'
+	id 'com.github.johnrengelman.shadow' version '7.1.1'
+	id 'com.github.ben-manes.versions' version '0.39.0'
 
 	id 'eclipse'
 	id 'idea'
@@ -40,13 +41,13 @@ configurations {
 }
 
 dependencies {
-	implementation 'com.github.Querz:NBT:4192a95c9d'
-	implementation 'org.json:json:20201115'
+	implementation 'com.github.Querz:NBT:6.1'
+	implementation 'org.json:json:20211205'
 	implementation 'ar.com.hjg:pngj:2.1.0'
-	implementation 'org.xerial:sqlite-jdbc:3.34.0'
+	implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 	implementation 'it.unimi.dsi:fastutil:8.5.6'
-	testImplementation 'junit:junit:4.12'
-	testImplementation 'commons-io:commons-io:2.6'
+	testImplementation 'junit:junit:4.13.2'
+	testImplementation 'commons-io:commons-io:2.11.0'
 }
 
 task copyRuntimeLibs(type: Copy) {


### PR DESCRIPTION
To improve the ease of development, I'd suggest to include 3 Gradle plugins:
* `application` - configuration of mainClass for `gradle run`
* `ben-manes.versions` - dependency update checking via `gradle dependencyUpdates`
* `JavaFX` - include JavaFX library/classpath which replaces the need for a Java SDK with bundled FX

Also updated dependencies to the newest (stable) versions.

I haven't checked if you'll run into build issues when including both the JavaFX Gradle plugin and a bundled SDK-JavaFX and how it works when building shippable executables. You might have to update the JDK in the `.travis.yml`.

I hope this PR is useful and helps further development! 🚀 