### PR TITLE
Don't load regions that only contain a header

### DIFF
--- a/src/main/java/net/querz/mcaselector/filter/BorderFilter.java
+++ b/src/main/java/net/querz/mcaselector/filter/BorderFilter.java
@@ -191,7 +191,7 @@ public class BorderFilter extends IntFilter {
 
 			// load region header
 			RegionMCAFile regionMCAFile = new RegionMCAFile(FileHelper.createMCAFilePath(region));
-			if (!regionMCAFile.getFile().exists() || regionMCAFile.getFile().length() <= 8192) {
+			if (!regionMCAFile.getFile().exists() || regionMCAFile.getFile().length() <= FileHelper.HEADER_SIZE) {
 				push(key, null);
 				return null;
 			}

--- a/src/main/java/net/querz/mcaselector/io/FileHelper.java
+++ b/src/main/java/net/querz/mcaselector/io/FileHelper.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 
 public final class FileHelper {
 
+	public static final int HEADER_SIZE = 8192;
 	public static final Pattern MCA_FILE_PATTERN = Pattern.compile("^r\\.-?\\d+\\.-?\\d+\\.mca$");
 	public static final Pattern REGION_GROUP_PATTERN = Pattern.compile("^r\\.(?<regionX>-?\\d+)\\.(?<regionZ>-?\\d+)\\.mca$");
 	public static final Pattern DAT_REGION_GROUP_PATTERN = Pattern.compile("^r\\.(?<regionX>-?\\d+)\\.(?<regionZ>-?\\d+)\\.dat$");

--- a/src/main/java/net/querz/mcaselector/io/job/ProcessDataJob.java
+++ b/src/main/java/net/querz/mcaselector/io/job/ProcessDataJob.java
@@ -1,6 +1,7 @@
 package net.querz.mcaselector.io.job;
 
 import net.querz.mcaselector.debug.Debug;
+import net.querz.mcaselector.io.FileHelper;
 import net.querz.mcaselector.io.Job;
 import net.querz.mcaselector.io.RegionDirectories;
 import net.querz.mcaselector.progress.Timer;
@@ -29,15 +30,15 @@ public abstract class ProcessDataJob extends Job {
 	}
 
 	public byte[] loadPoiHeader() {
-		return load(getRegionDirectories().getPoi(), 8192);
+		return load(getRegionDirectories().getPoi(), FileHelper.HEADER_SIZE);
 	}
 
 	public byte[] loadEntitiesHeader() {
-		return load(getRegionDirectories().getEntities(), 8192);
+		return load(getRegionDirectories().getEntities(), FileHelper.HEADER_SIZE);
 	}
 
 	public byte[] loadRegionHeader() {
-		return load(getRegionDirectories().getRegion(), 8192);
+		return load(getRegionDirectories().getRegion(), FileHelper.HEADER_SIZE);
 	}
 
 	protected byte[] load(File file) {

--- a/src/main/java/net/querz/mcaselector/io/mca/MCAFile.java
+++ b/src/main/java/net/querz/mcaselector/io/mca/MCAFile.java
@@ -301,7 +301,7 @@ public abstract class MCAFile<T extends Chunk> {
 
 	public T loadSingleChunk(Point2i chunk) throws IOException {
 		// ignore files that don't have a full header
-		if (file.length() < 8192) {
+		if (file.length() < FileHelper.HEADER_SIZE) {
 			return null;
 		}
 

--- a/src/main/java/net/querz/mcaselector/io/mca/Region.java
+++ b/src/main/java/net/querz/mcaselector/io/mca/Region.java
@@ -5,6 +5,7 @@ import net.querz.mcaselector.changer.Field;
 import net.querz.mcaselector.debug.Debug;
 import net.querz.mcaselector.filter.Filter;
 import net.querz.mcaselector.io.ByteArrayPointer;
+import net.querz.mcaselector.io.FileHelper;
 import net.querz.mcaselector.io.RegionDirectories;
 import net.querz.mcaselector.io.SelectionData;
 import net.querz.mcaselector.point.Point2i;
@@ -28,7 +29,7 @@ public class Region {
 
 	public static Region loadRegion(RegionDirectories dirs, byte[] regionData, byte[] poiData, byte[] entitiesData) throws IOException {
 		Region r = new Region();
-		if (dirs.getRegion() != null && regionData != null) {
+		if (dirs.getRegion() != null && dirs.getRegion().length() > FileHelper.HEADER_SIZE && regionData != null) {
 			r.loadRegion(dirs.getRegion(), new ByteArrayPointer(regionData));
 			r.location = dirs.getLocation();
 		}

--- a/src/main/java/net/querz/mcaselector/tiles/ImagePool.java
+++ b/src/main/java/net/querz/mcaselector/tiles/ImagePool.java
@@ -251,7 +251,7 @@ public final class ImagePool {
 		ForkJoinPool threadPool = new ForkJoinPool(Config.getProcessThreads());
 		try {
 			List<Point2i> points = threadPool.submit(() -> Arrays.stream(files).parallel()
-					.filter(file -> file.length() > 8192) // only files that have more data than just the header
+					.filter(file -> file.length() > FileHelper.HEADER_SIZE) // only files that have more data than just the header
 					.map(file -> {
 						Point2i p = FileHelper.parseMCAFileName(file);
 						if (task != null && p != null) {


### PR DESCRIPTION
Avoids loading regions that only contain a header. In my case, this fixed an error when a region file only contained a header but was missing timestamps.