### PR TITLE
Height slider

### DIFF
--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -321,6 +321,7 @@ public final class Config {
 	}
 
 	public static void setRenderHeight(int renderHeight) {
+		System.out.println("set render height to " + renderHeight);
 		Config.renderHeight = renderHeight;
 	}
 

--- a/src/main/java/net/querz/mcaselector/Config.java
+++ b/src/main/java/net/querz/mcaselector/Config.java
@@ -321,7 +321,6 @@ public final class Config {
 	}
 
 	public static void setRenderHeight(int renderHeight) {
-		System.out.println("set render height to " + renderHeight);
 		Config.renderHeight = renderHeight;
 	}
 

--- a/src/main/java/net/querz/mcaselector/ui/UIFactory.java
+++ b/src/main/java/net/querz/mcaselector/ui/UIFactory.java
@@ -129,39 +129,6 @@ public final class UIFactory {
 		return sliderValue;
 	}
 
-	public static NumberTextField attachFreeNumberTextFieldToSlider(Slider slider, int init) {
-		NumberTextField sliderValue = new NumberTextField(-64, 319);
-		sliderValue.setText(init + "");
-		sliderValue.getStyleClass().add("slider-value-field");
-		DataProperty<Boolean> sliderValuePropertyListenerDisabled = new DataProperty<>(false);
-		sliderValue.valueProperty().addListener((v, o, n) -> {
-			sliderValuePropertyListenerDisabled.set(true);
-			slider.setValue(n.intValue());
-			sliderValuePropertyListenerDisabled.set(false);
-		});
-		slider.setOnScroll(e -> {
-			if (e.getDeltaY() > 0) {
-				slider.setValue(slider.getValue() + 1);
-				sliderValue.setText((int) Math.round(slider.getValue()) + "");
-			} else if (e.getDeltaY() < 0) {
-				slider.setValue(slider.getValue() - 1);
-				sliderValue.setText((int) Math.round(slider.getValue()) + "");
-			}
-		});
-		slider.valueProperty().addListener((v, o, n) -> {
-			if (!sliderValuePropertyListenerDisabled.get()) {
-				sliderValue.setText((int) Math.round(slider.getValue()) + "");
-			}
-		});
-		sliderValue.setOnScrollEvent(e -> {
-			if (sliderValue.getValue() <= slider.getMax() && sliderValue.getValue() >= slider.getMin()) {
-				slider.setValue(sliderValue.getValue());
-			}
-		});
-		sliderValue.setText((int) Math.round(slider.getValue()) + "");
-		return sliderValue;
-	}
-
 	public static Hyperlink hyperlink(String text, String url, Node graphic) {
 		Hyperlink hyperlink;
 		if (graphic == null) {

--- a/src/main/java/net/querz/mcaselector/ui/UIFactory.java
+++ b/src/main/java/net/querz/mcaselector/ui/UIFactory.java
@@ -15,7 +15,10 @@ import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.ScrollEvent;
+import net.querz.mcaselector.Config;
+import net.querz.mcaselector.property.DataProperty;
 import net.querz.mcaselector.text.Translation;
+import net.querz.mcaselector.ui.component.NumberTextField;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.awt.*;
@@ -122,6 +125,39 @@ public final class UIFactory {
 		sliderValue.setOnScroll(scrollEvent);
 		slider.setOnScroll(scrollEvent);
 
+		sliderValue.setText((int) Math.round(slider.getValue()) + "");
+		return sliderValue;
+	}
+
+	public static NumberTextField attachFreeNumberTextFieldToSlider(Slider slider, int init) {
+		NumberTextField sliderValue = new NumberTextField(-64, 319);
+		sliderValue.setText(init + "");
+		sliderValue.getStyleClass().add("slider-value-field");
+		DataProperty<Boolean> sliderValuePropertyListenerDisabled = new DataProperty<>(false);
+		sliderValue.valueProperty().addListener((v, o, n) -> {
+			sliderValuePropertyListenerDisabled.set(true);
+			slider.setValue(n.intValue());
+			sliderValuePropertyListenerDisabled.set(false);
+		});
+		slider.setOnScroll(e -> {
+			if (e.getDeltaY() > 0) {
+				slider.setValue(slider.getValue() + 1);
+				sliderValue.setText((int) Math.round(slider.getValue()) + "");
+			} else if (e.getDeltaY() < 0) {
+				slider.setValue(slider.getValue() - 1);
+				sliderValue.setText((int) Math.round(slider.getValue()) + "");
+			}
+		});
+		slider.valueProperty().addListener((v, o, n) -> {
+			if (!sliderValuePropertyListenerDisabled.get()) {
+				sliderValue.setText((int) Math.round(slider.getValue()) + "");
+			}
+		});
+		sliderValue.setOnScrollEvent(e -> {
+			if (sliderValue.getValue() <= slider.getMax() && sliderValue.getValue() >= slider.getMin()) {
+				slider.setValue(sliderValue.getValue());
+			}
+		});
 		sliderValue.setText((int) Math.round(slider.getValue()) + "");
 		return sliderValue;
 	}

--- a/src/main/java/net/querz/mcaselector/ui/component/HeightSlider.java
+++ b/src/main/java/net/querz/mcaselector/ui/component/HeightSlider.java
@@ -1,0 +1,101 @@
+package net.querz.mcaselector.ui.component;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.scene.control.Label;
+import javafx.scene.control.Slider;
+import javafx.scene.layout.HBox;
+import javafx.util.StringConverter;
+
+public class HeightSlider extends HBox {
+
+	private final IntegerProperty valueProperty = new SimpleIntegerProperty();
+
+	private final Slider slider = new Slider(-64, 319, 319);
+	private final Label heightMinLabel = new Label("-64");
+	private final Label heightMaxLabel = new Label("319");
+	private final NumberTextField heightField = new NumberTextField(-64, 2047);
+	private final BooleanProperty sliderValuePropertyDisabled = new SimpleBooleanProperty(false);
+
+	/*
+	* when scrolling on slider: always set value in text field if slider value changed
+	* when scrolling on text field: set slider value if text field value is in range of slider
+	* when typing on text field: set slider value if text field value is in range of slider.
+	*   if text field value is larger than slider max, set slider to max
+	*   if text field value is smaller than slider min, set slider to min
+	* */
+
+	public HeightSlider(int init) {
+		valueProperty.set(init);
+		getStyleClass().add("option-bar-slider-box");
+		heightField.getStyleClass().add("slider-value-field");
+		slider.setSnapToTicks(true);
+		slider.setShowTickLabels(false);
+		slider.setShowTickMarks(false);
+		slider.setMajorTickUnit(32);
+		slider.setMinorTickCount(384);
+		slider.setPrefWidth(300);
+		slider.setBlockIncrement(1);
+		slider.setValue(init);
+		heightField.valueProperty().set(init);
+		slider.setLabelFormatter(new StringConverter<>() {
+			@Override
+			public String toString(Double object) {
+				return null;
+			}
+
+			@Override
+			public Double fromString(String string) {
+				return null;
+			}
+		});
+
+		slider.setOnScroll(e -> {
+			int delta = e.getDeltaY() > 0 ? 1 : -1;
+			slider.setValue(slider.getValue() + delta);
+		});
+
+		slider.valueProperty().addListener((v, o, n) -> {
+			if (o.intValue() != n.intValue()) {
+				heightField.setText(n.intValue() + "");
+			}
+		});
+
+		heightField.valueProperty().addListener((v, o, n) -> {
+			if (o.intValue() != n.intValue()) {
+				valueProperty.set(n.intValue());
+				if (n.intValue() > slider.getMax()) {
+					slider.setValue(319);
+				} else if (n.intValue() < slider.getMin()) {
+					slider.setValue(-64);
+				} else {
+					slider.setValue(n.intValue());
+				}
+			}
+		});
+
+		// value property sets text field value
+		valueProperty.addListener((v, o, n) -> {
+			heightField.setText(n.intValue() + "");
+		});
+
+		getChildren().addAll(heightMinLabel, slider, heightMaxLabel, heightField);
+	}
+
+	public IntegerProperty valueProperty() {
+		return valueProperty;
+	}
+
+	public int getValue() {
+		return valueProperty.get();
+	}
+
+	public void disable(boolean disable) {
+		slider.setDisable(disable);
+		heightMinLabel.setDisable(disable);
+		heightMaxLabel.setDisable(disable);
+		heightField.setDisable(disable);
+	}
+}

--- a/src/main/java/net/querz/mcaselector/ui/component/HeightSlider.java
+++ b/src/main/java/net/querz/mcaselector/ui/component/HeightSlider.java
@@ -1,8 +1,6 @@
 package net.querz.mcaselector.ui.component;
 
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
@@ -17,7 +15,6 @@ public class HeightSlider extends HBox {
 	private final Label heightMinLabel = new Label("-64");
 	private final Label heightMaxLabel = new Label("319");
 	private final NumberTextField heightField = new NumberTextField(-64, 2047);
-	private final BooleanProperty sliderValuePropertyDisabled = new SimpleBooleanProperty(false);
 
 	/*
 	* when scrolling on slider: always set value in text field if slider value changed
@@ -27,30 +24,33 @@ public class HeightSlider extends HBox {
 	*   if text field value is smaller than slider min, set slider to min
 	* */
 
-	public HeightSlider(int init) {
+	public HeightSlider(int init, boolean showCustomlabels) {
 		valueProperty.set(init);
-		getStyleClass().add("option-bar-slider-box");
 		heightField.getStyleClass().add("slider-value-field");
 		slider.setSnapToTicks(true);
-		slider.setShowTickLabels(false);
-		slider.setShowTickMarks(false);
+		slider.setShowTickLabels(!showCustomlabels);
+		slider.setShowTickMarks(!showCustomlabels);
 		slider.setMajorTickUnit(32);
 		slider.setMinorTickCount(384);
 		slider.setPrefWidth(300);
 		slider.setBlockIncrement(1);
 		slider.setValue(init);
-		heightField.valueProperty().set(init);
-		slider.setLabelFormatter(new StringConverter<>() {
-			@Override
-			public String toString(Double object) {
-				return null;
-			}
 
-			@Override
-			public Double fromString(String string) {
-				return null;
-			}
-		});
+		heightField.valueProperty().set(init);
+
+		if (showCustomlabels) {
+			slider.setLabelFormatter(new StringConverter<>() {
+				@Override
+				public String toString(Double object) {
+					return null;
+				}
+
+				@Override
+				public Double fromString(String string) {
+					return null;
+				}
+			});
+		}
 
 		slider.setOnScroll(e -> {
 			int delta = e.getDeltaY() > 0 ? 1 : -1;
@@ -77,11 +77,13 @@ public class HeightSlider extends HBox {
 		});
 
 		// value property sets text field value
-		valueProperty.addListener((v, o, n) -> {
-			heightField.setText(n.intValue() + "");
-		});
+		valueProperty.addListener((v, o, n) -> heightField.setText(n.intValue() + ""));
 
-		getChildren().addAll(heightMinLabel, slider, heightMaxLabel, heightField);
+		if (showCustomlabels) {
+			getChildren().addAll(heightMinLabel, slider, heightMaxLabel, heightField);
+		} else {
+			getChildren().addAll(slider, heightField);
+		}
 	}
 
 	public IntegerProperty valueProperty() {
@@ -97,5 +99,9 @@ public class HeightSlider extends HBox {
 		heightMinLabel.setDisable(disable);
 		heightMaxLabel.setDisable(disable);
 		heightField.setDisable(disable);
+	}
+
+	public void setMajorTickUnit(int unit) {
+		slider.setMajorTickUnit(unit);
 	}
 }

--- a/src/main/java/net/querz/mcaselector/ui/component/NumberTextField.java
+++ b/src/main/java/net/querz/mcaselector/ui/component/NumberTextField.java
@@ -1,0 +1,76 @@
+package net.querz.mcaselector.ui.component;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.event.EventHandler;
+import javafx.scene.control.TextField;
+import javafx.scene.input.ScrollEvent;
+
+public class NumberTextField extends TextField {
+
+	private final IntegerProperty valueProperty = new SimpleIntegerProperty();
+
+	private EventHandler<? super ScrollEvent> onScroll;
+
+	private final int min, max;
+
+	public NumberTextField(int min, int max) {
+		this.min = min;
+		this.max = max;
+		textProperty().addListener((v, o, n) -> {
+			if (!n.matches("-?\\d*")) {
+				setText(n.replaceAll("[^\\-\\d]", ""));
+			} else if ("".equals(n)) {
+				valueProperty.set(0);
+			} else {
+				try {
+					int value = Integer.parseInt(n);
+					if (value < min) {
+						value = min;
+					} else if (value > max) {
+						value = max;
+					}
+					valueProperty.set(value);
+					setText(value + "");
+				} catch (NumberFormatException ex) {
+					valueProperty.set(0);
+				}
+			}
+		});
+		setOnScroll(e -> {
+			if (e.getDeltaY() > 0) {
+				setText(incrementAndGet(1) + "");
+			} else if (e.getDeltaY() < 0) {
+				setText(incrementAndGet(-1) + "");
+			}
+			if (onScroll != null) {
+				onScroll.handle(e);
+			}
+		});
+		valueProperty.addListener((v, o, n) -> {
+			if (n.intValue() == 0) {
+				setText("");
+			} else {
+				setText(n + "");
+			}
+		});
+	}
+
+	public void setOnScrollEvent(EventHandler<? super ScrollEvent> value) {
+		onScroll = value;
+	}
+
+	private int incrementAndGet(int inc) {
+		int newValue = valueProperty.get() + inc;
+		valueProperty.set(newValue);
+		return newValue;
+	}
+
+	public IntegerProperty valueProperty() {
+		return valueProperty;
+	}
+
+	public int getValue() {
+		return valueProperty.get();
+	}
+}

--- a/src/main/java/net/querz/mcaselector/ui/component/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/component/OptionBar.java
@@ -54,12 +54,7 @@ public class OptionBar extends BorderPane {
 	private final Menu tools = UIFactory.menu(Translation.MENU_TOOLS);
 	private final Label about = UIFactory.label(Translation.MENU_ABOUT);
 
-	private final HeightSlider hSlider = new HeightSlider(319);
-//	private final Slider height = new Slider(-64, 319, 319);
-//	private final Label heightMinLabel = new Label("-64");
-//	private final Label heightMaxLabel = new Label("319");
-//	private final NumberTextField heightField = UIFactory.attachFreeNumberTextFieldToSlider(height, Config.getRenderHeight());
-
+	private final HeightSlider hSlider = new HeightSlider(319, true);
 	private final MenuItem openWorld = UIFactory.menuItem(Translation.MENU_FILE_OPEN_WORLD);
 	private final MenuItem settings = UIFactory.menuItem(Translation.MENU_FILE_SETTINGS);
 	private final MenuItem renderSettings = UIFactory.menuItem(Translation.MENU_FILE_RENDER_SETTINGS);
@@ -129,45 +124,8 @@ public class OptionBar extends BorderPane {
 		Menu aboutMenu = new Menu();
 		aboutMenu.setGraphic(about);
 
-//		height.setSnapToTicks(true);
-//		height.setShowTickLabels(false);
-//		height.setShowTickMarks(false);
-//		height.setMajorTickUnit(32);
-//		height.setMinorTickCount(384);
-//		height.setPrefWidth(300);
-//		height.setLabelFormatter(new StringConverter<>() {
-//			@Override
-//			public String toString(Double object) {
-//				return null;
-//			}
-//
-//			@Override
-//			public Double fromString(String string) {
-//				return null;
-//			}
-//		});
-//		height.setBlockIncrement(1);
-//
-//		height.setOnMouseReleased(e -> {
-//			if (heightDisabled.get()) {
-//				e.consume();
-//				return;
-//			}
-//			if (heightValue.get() != height.getValue()) {
-//				heightValue.set(height.getValue());
-//			}
-//		});
-//
-//		height.setOnKeyReleased(e -> {
-//			if (heightDisabled.get()) {
-//				e.consume();
-//				return;
-//			}
-//			if (heightValue.get() != heightField.getValue()) {
-//				heightValue.set(height.getValue());
-//			}
-//		});
-//
+		hSlider.getStyleClass().add("option-bar-slider-box");
+
 		heightValue.bind(hSlider.valueProperty());
 
 		heightValue.addListener((v, o, n) -> {
@@ -182,21 +140,6 @@ public class OptionBar extends BorderPane {
 				});
 			}
 		});
-//
-//		HBox heightSlider = new HBox();
-//		heightSlider.getStyleClass().add("option-bar-slider-box");
-//
-//		heightField.textProperty().addListener((v, o, n) -> {
-//			if (heightDisabled.get()) {
-//				return;
-//			}
-//			if (heightValue.get() != heightField.getValue()) {
-//				heightValue.set(heightField.getValue());
-//			}
-//		});
-//
-//		heightSlider.getChildren().addAll(heightMinLabel, height, heightMaxLabel, heightField);
-
 
 		// when we press escape we want to give the focus back to the tile map
 		setOnKeyPressed(e -> {
@@ -307,10 +250,6 @@ public class OptionBar extends BorderPane {
 		nextOverlay.setDisable(!enabled);
 		nextOverlayType.setDisable(!enabled);
 		hSlider.setDisable(!enabled);
-//		height.setDisable(!enabled);
-//		heightMinLabel.setDisable(!enabled);
-//		heightMaxLabel.setDisable(!enabled);
-//		heightField.setDisable(!enabled);
 	}
 
 	public void setEditOverlaysEnabled(boolean enabled) {

--- a/src/main/java/net/querz/mcaselector/ui/component/OptionBar.java
+++ b/src/main/java/net/querz/mcaselector/ui/component/OptionBar.java
@@ -2,8 +2,10 @@ package net.querz.mcaselector.ui.component;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.control.*;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
@@ -27,6 +29,7 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
+import java.util.Arrays;
 
 public class OptionBar extends BorderPane {
 	/*
@@ -50,10 +53,12 @@ public class OptionBar extends BorderPane {
 	private final Menu selection = UIFactory.menu(Translation.MENU_SELECTION);
 	private final Menu tools = UIFactory.menu(Translation.MENU_TOOLS);
 	private final Label about = UIFactory.label(Translation.MENU_ABOUT);
-	private final Slider height = new Slider(-64, 319, 319);
-	private final Label heightMinLabel = new Label("-64");
-	private final Label heightMaxLabel = new Label("319");
-	private final TextField heightField = UIFactory.attachTextFieldToSlider(height);
+
+	private final HeightSlider hSlider = new HeightSlider(319);
+//	private final Slider height = new Slider(-64, 319, 319);
+//	private final Label heightMinLabel = new Label("-64");
+//	private final Label heightMaxLabel = new Label("319");
+//	private final NumberTextField heightField = UIFactory.attachFreeNumberTextFieldToSlider(height, Config.getRenderHeight());
 
 	private final MenuItem openWorld = UIFactory.menuItem(Translation.MENU_FILE_OPEN_WORLD);
 	private final MenuItem settings = UIFactory.menuItem(Translation.MENU_FILE_SETTINGS);
@@ -90,7 +95,7 @@ public class OptionBar extends BorderPane {
 
 	private int previousSelectedChunks = 0;
 	private boolean previousInvertedSelection = false;
-	private final DoubleProperty heightValue = new SimpleDoubleProperty(height.getValue());
+	private final IntegerProperty heightValue = new SimpleIntegerProperty(319);
 	private final BooleanProperty heightDisabled = new SimpleBooleanProperty(false);
 
 	public OptionBar(TileMap tileMap, Stage primaryStage) {
@@ -124,78 +129,74 @@ public class OptionBar extends BorderPane {
 		Menu aboutMenu = new Menu();
 		aboutMenu.setGraphic(about);
 
-		height.setSnapToTicks(true);
-		height.setShowTickLabels(false);
-		height.setShowTickMarks(false);
-		height.setMajorTickUnit(32);
-		height.setMinorTickCount(384);
-		height.setPrefWidth(300);
-		height.setLabelFormatter(new StringConverter<>() {
-			@Override
-			public String toString(Double object) {
-				return null;
-			}
-
-			@Override
-			public Double fromString(String string) {
-				return null;
-			}
-		});
-		height.setBlockIncrement(1);
-
-		height.setOnMouseReleased(e -> {
-			if (heightDisabled.get()) {
-				e.consume();
-				return;
-			}
-			if (heightValue.get() != height.getValue()) {
-				heightValue.set(height.getValue());
-			}
-		});
-
-		height.setOnKeyReleased(e -> {
-			if (heightDisabled.get()) {
-				e.consume();
-				return;
-			}
-			if (heightValue.get() != height.getValue()) {
-				heightValue.set(height.getValue());
-			}
-		});
+//		height.setSnapToTicks(true);
+//		height.setShowTickLabels(false);
+//		height.setShowTickMarks(false);
+//		height.setMajorTickUnit(32);
+//		height.setMinorTickCount(384);
+//		height.setPrefWidth(300);
+//		height.setLabelFormatter(new StringConverter<>() {
+//			@Override
+//			public String toString(Double object) {
+//				return null;
+//			}
+//
+//			@Override
+//			public Double fromString(String string) {
+//				return null;
+//			}
+//		});
+//		height.setBlockIncrement(1);
+//
+//		height.setOnMouseReleased(e -> {
+//			if (heightDisabled.get()) {
+//				e.consume();
+//				return;
+//			}
+//			if (heightValue.get() != height.getValue()) {
+//				heightValue.set(height.getValue());
+//			}
+//		});
+//
+//		height.setOnKeyReleased(e -> {
+//			if (heightDisabled.get()) {
+//				e.consume();
+//				return;
+//			}
+//			if (heightValue.get() != heightField.getValue()) {
+//				heightValue.set(height.getValue());
+//			}
+//		});
+//
+		heightValue.bind(hSlider.valueProperty());
 
 		heightValue.addListener((v, o, n) -> {
 			if (!tileMap.getDisabled()) {
-				int value = (int) Math.round(n.doubleValue());
 				heightDisabled.set(true);
-				Config.setRenderHeight(value);
-
+				Config.setRenderHeight(n.intValue());
 				CacheHelper.clearAllCacheAsync(tileMap, () -> {
 					heightDisabled.set(false);
-					if (height.getValue() != heightValue.get()) {
-						heightValue.set(height.getValue());
+					if (hSlider.getValue() != heightValue.get()) {
+						heightValue.set(hSlider.getValue());
 					}
 				});
 			}
 		});
+//
+//		HBox heightSlider = new HBox();
+//		heightSlider.getStyleClass().add("option-bar-slider-box");
+//
+//		heightField.textProperty().addListener((v, o, n) -> {
+//			if (heightDisabled.get()) {
+//				return;
+//			}
+//			if (heightValue.get() != heightField.getValue()) {
+//				heightValue.set(heightField.getValue());
+//			}
+//		});
+//
+//		heightSlider.getChildren().addAll(heightMinLabel, height, heightMaxLabel, heightField);
 
-		HBox heightSlider = new HBox();
-		heightSlider.getStyleClass().add("option-bar-slider-box");
-
-		heightField.textProperty().addListener((v, o, n) -> {
-			try {
-				int parsed = Integer.parseInt(n);
-				if (heightDisabled.get()) {
-					return;
-				}
-				if (heightValue.get() != height.getValue()) {
-					heightValue.set(parsed);
-				}
-			} catch (NumberFormatException ex) {
-				// do nothing
-			}
-		});
-
-		heightSlider.getChildren().addAll(heightMinLabel, height, heightMaxLabel, heightField);
 
 		// when we press escape we want to give the focus back to the tile map
 		setOnKeyPressed(e -> {
@@ -278,7 +279,7 @@ public class OptionBar extends BorderPane {
 		Toolkit.getDefaultToolkit().getSystemClipboard().addFlavorListener(e -> paste.setDisable(!hasValidClipboardContent(tileMap) || tileMap.getDisabled()));
 
 		setLeft(menuBar);
-		setRight(heightSlider);
+		setRight(hSlider);
 	}
 
 	private void onUpdate(TileMap tileMap) {
@@ -305,10 +306,11 @@ public class OptionBar extends BorderPane {
 		paste.setDisable(!enabled || !hasValidClipboardContent(tileMap));
 		nextOverlay.setDisable(!enabled);
 		nextOverlayType.setDisable(!enabled);
-		height.setDisable(!enabled);
-		heightMinLabel.setDisable(!enabled);
-		heightMaxLabel.setDisable(!enabled);
-		heightField.setDisable(!enabled);
+		hSlider.setDisable(!enabled);
+//		height.setDisable(!enabled);
+//		heightMinLabel.setDisable(!enabled);
+//		heightMaxLabel.setDisable(!enabled);
+//		heightField.setDisable(!enabled);
 	}
 
 	public void setEditOverlaysEnabled(boolean enabled) {
@@ -335,10 +337,7 @@ public class OptionBar extends BorderPane {
 		return flavors.length == 1 && flavors[0].equals(ClipboardSelection.SELECTION_DATA_FLAVOR);
 	}
 
-	public void setRenderHeight(double height) {
-		this.height.setValue(height);
-		if (Config.getRenderHeight() != height) {
-			heightValue.set(height);
-		}
+	public void setRenderHeight(int height) {
+		hSlider.valueProperty().set(height);
 	}
 }

--- a/src/main/java/net/querz/mcaselector/ui/dialog/SettingsDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/dialog/SettingsDialog.java
@@ -15,6 +15,7 @@ import net.querz.mcaselector.io.WorldDirectories;
 import net.querz.mcaselector.property.DataProperty;
 import net.querz.mcaselector.text.Translation;
 import net.querz.mcaselector.ui.component.FileTextField;
+import net.querz.mcaselector.ui.component.NumberTextField;
 import net.querz.mcaselector.ui.component.TileMapBox;
 import net.querz.mcaselector.ui.UIFactory;
 import java.io.File;
@@ -37,6 +38,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 	private final Slider writeThreadsSlider = createSlider(1, processorCount, 1, Config.getWriteThreads());
 	private final Slider maxLoadedFilesSlider = createSlider(1, (int) Math.max(Math.ceil(maxMemory / 1_000_000_000D) * 6, 4), 1, Config.getMaxLoadedFiles());
 	private final Slider heightSlider = new Slider(-64, 319, 319);
+	private final NumberTextField heightField;
 	private final CheckBox layerOnly = new CheckBox();
 	private final CheckBox caves = new CheckBox();
 	private final Button regionSelectionColorPreview = new Button();
@@ -88,34 +90,6 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 			tileMapBackgrounds.setValue(TileMapBox.TileMapBoxBackground.valueOf(Config.DEFAULT_TILEMAP_BACKGROUND));
 			mcSavesDir.setFile(Config.DEFAULT_MC_SAVES_DIR == null ? null : new File(Config.DEFAULT_MC_SAVES_DIR));
 			debugCheckBox.setSelected(Config.DEFAULT_DEBUG);
-		});
-
-		setResultConverter(c -> {
-			if (c.getButtonData() == ButtonBar.ButtonData.OK_DONE) {
-				return new Result(
-					languages.getSelectionModel().getSelectedItem(),
-					(int) processThreadsSlider.getValue(),
-					(int) writeThreadsSlider.getValue(),
-					(int) maxLoadedFilesSlider.getValue(),
-					regionSelectionColor,
-					chunkSelectionColor,
-					pasteChunksColor,
-					shadeCheckBox.isSelected(),
-					shadeWaterCheckBox.isSelected(),
-					showNonexistentRegionsCheckBox.isSelected(),
-					smoothRendering.isSelected(),
-					smoothOverlays.isSelected(),
-					tileMapBackgrounds.getSelectionModel().getSelectedItem(),
-					mcSavesDir.getFile(),
-					debugCheckBox.isSelected(),
-					(int) heightSlider.getValue(),
-					layerOnly.isSelected(),
-					caves.isSelected(),
-					poiField.getFile(),
-					entitiesField.getFile()
-				);
-			}
-			return null;
 		});
 
 		languages.getItems().addAll(Translation.getAvailableLanguages());
@@ -238,6 +212,8 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		heightSlider.setMinorTickCount(384);
 		heightSlider.setBlockIncrement(1);
 
+		heightField = UIFactory.attachFreeNumberTextFieldToSlider(heightSlider, Config.getRenderHeight());
+
 		toggleGroup.selectedToggleProperty().addListener((v, o, n) -> {
 			if (n == null) {
 				toggleGroup.selectToggle(o);
@@ -315,7 +291,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		shadingAndSmooth.getChildren().addAll(shade, smooth);
 
 		GridPane layerGrid = createGrid();
-		addPairToGrid(layerGrid, 0, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_HEIGHT), heightSlider, UIFactory.attachTextFieldToSlider(heightSlider));
+		addPairToGrid(layerGrid, 0, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_HEIGHT), heightSlider, UIFactory.attachFreeNumberTextFieldToSlider(heightSlider, Config.getRenderHeight()));
 		addPairToGrid(layerGrid, 1, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_LAYER_ONLY), layerOnly);
 		addPairToGrid(layerGrid, 2, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_CAVES), caves);
 		BorderedTitledPane layers = new BorderedTitledPane(Translation.DIALOG_SETTINGS_RENDERING_LAYERS, layerGrid);
@@ -370,6 +346,33 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		content.getChildren().addAll(tabBox, tabPane);
 
 		getDialogPane().setContent(content);
+
+		setResultConverter(c -> {
+			if (c.getButtonData() == ButtonBar.ButtonData.OK_DONE) {
+				return new Result(
+					languages.getSelectionModel().getSelectedItem(),
+					(int) processThreadsSlider.getValue(),
+					(int) writeThreadsSlider.getValue(),
+					(int) maxLoadedFilesSlider.getValue(),
+					regionSelectionColor,
+					chunkSelectionColor,
+					pasteChunksColor,
+					shadeCheckBox.isSelected(),
+					shadeWaterCheckBox.isSelected(),
+					showNonexistentRegionsCheckBox.isSelected(),
+					smoothRendering.isSelected(),
+					smoothOverlays.isSelected(),
+					tileMapBackgrounds.getSelectionModel().getSelectedItem(),
+					mcSavesDir.getFile(),
+					debugCheckBox.isSelected(),
+					heightField.getValue(),
+					layerOnly.isSelected(),
+					caves.isSelected(),
+					poiField.getFile(),
+					entitiesField.getFile());
+			}
+			return null;
+		});
 	}
 
 	private <T extends Node> T withAlignment(T node) {

--- a/src/main/java/net/querz/mcaselector/ui/dialog/SettingsDialog.java
+++ b/src/main/java/net/querz/mcaselector/ui/dialog/SettingsDialog.java
@@ -3,6 +3,7 @@ package net.querz.mcaselector.ui.dialog;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
@@ -15,6 +16,7 @@ import net.querz.mcaselector.io.WorldDirectories;
 import net.querz.mcaselector.property.DataProperty;
 import net.querz.mcaselector.text.Translation;
 import net.querz.mcaselector.ui.component.FileTextField;
+import net.querz.mcaselector.ui.component.HeightSlider;
 import net.querz.mcaselector.ui.component.NumberTextField;
 import net.querz.mcaselector.ui.component.TileMapBox;
 import net.querz.mcaselector.ui.UIFactory;
@@ -37,8 +39,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 	private final Slider processThreadsSlider = createSlider(1, processorCount * 2, 1, Config.getProcessThreads());
 	private final Slider writeThreadsSlider = createSlider(1, processorCount, 1, Config.getWriteThreads());
 	private final Slider maxLoadedFilesSlider = createSlider(1, (int) Math.max(Math.ceil(maxMemory / 1_000_000_000D) * 6, 4), 1, Config.getMaxLoadedFiles());
-	private final Slider heightSlider = new Slider(-64, 319, 319);
-	private final NumberTextField heightField;
+	private final HeightSlider hSlider = new HeightSlider(Config.getRenderHeight(), false);
 	private final CheckBox layerOnly = new CheckBox();
 	private final CheckBox caves = new CheckBox();
 	private final Button regionSelectionColorPreview = new Button();
@@ -85,7 +86,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 			showNonexistentRegionsCheckBox.setSelected(Config.DEFAULT_SHOW_NONEXISTENT_REGIONS);
 			smoothRendering.setSelected(Config.DEFAULT_SMOOTH_RENDERING);
 			smoothOverlays.setSelected(Config.DEFAULT_SMOOTH_OVERLAYS);
-			heightSlider.setValue(heightSlider.getMax());
+			hSlider.valueProperty().set(hSlider.getValue());
 			caves.setSelected(Config.DEFAULT_RENDER_CAVES);
 			tileMapBackgrounds.setValue(TileMapBox.TileMapBoxBackground.valueOf(Config.DEFAULT_TILEMAP_BACKGROUND));
 			mcSavesDir.setFile(Config.DEFAULT_MC_SAVES_DIR == null ? null : new File(Config.DEFAULT_MC_SAVES_DIR));
@@ -126,7 +127,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		showNonexistentRegionsCheckBox.setSelected(Config.showNonExistentRegions());
 		smoothRendering.setSelected(Config.smoothRendering());
 		smoothOverlays.setSelected(Config.smoothOverlays());
-		heightSlider.setValue(Config.getRenderHeight());
+		hSlider.valueProperty().set(Config.getRenderHeight());
 		layerOnly.setSelected(Config.renderLayerOnly());
 		caves.setSelected(Config.renderCaves());
 		tileMapBackgrounds.getItems().addAll(TileMapBox.TileMapBoxBackground.values());
@@ -206,13 +207,8 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 			entitiesField.setFile(worldDirectories.getEntities());
 		}
 
-		heightSlider.setValue(Config.getRenderHeight());
-		heightSlider.setSnapToTicks(true);
-		heightSlider.setMajorTickUnit(64);
-		heightSlider.setMinorTickCount(384);
-		heightSlider.setBlockIncrement(1);
-
-		heightField = UIFactory.attachFreeNumberTextFieldToSlider(heightSlider, Config.getRenderHeight());
+		hSlider.setMajorTickUnit(64);
+		hSlider.setAlignment(Pos.CENTER_LEFT);
 
 		toggleGroup.selectedToggleProperty().addListener((v, o, n) -> {
 			if (n == null) {
@@ -291,7 +287,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 		shadingAndSmooth.getChildren().addAll(shade, smooth);
 
 		GridPane layerGrid = createGrid();
-		addPairToGrid(layerGrid, 0, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_HEIGHT), heightSlider, UIFactory.attachFreeNumberTextFieldToSlider(heightSlider, Config.getRenderHeight()));
+		addPairToGrid(layerGrid, 0, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_HEIGHT), hSlider);
 		addPairToGrid(layerGrid, 1, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_LAYER_ONLY), layerOnly);
 		addPairToGrid(layerGrid, 2, UIFactory.label(Translation.DIALOG_SETTINGS_RENDERING_LAYERS_RENDER_CAVES), caves);
 		BorderedTitledPane layers = new BorderedTitledPane(Translation.DIALOG_SETTINGS_RENDERING_LAYERS, layerGrid);
@@ -365,7 +361,7 @@ public class SettingsDialog extends Dialog<SettingsDialog.Result> {
 					tileMapBackgrounds.getSelectionModel().getSelectedItem(),
 					mcSavesDir.getFile(),
 					debugCheckBox.isSelected(),
-					heightField.getValue(),
+					hSlider.getValue(),
 					layerOnly.isSelected(),
 					caves.isSelected(),
 					poiField.getFile(),

--- a/src/main/java/net/querz/mcaselector/version/Helper.java
+++ b/src/main/java/net/querz/mcaselector/version/Helper.java
@@ -242,4 +242,15 @@ public final class Helper {
 			}
 		}
 	}
+
+	public static int findHighestSection(ListTag sections, int lowest) {
+		int max = lowest;
+		int current;
+		for (CompoundTag section : sections.iterateType(CompoundTag.TYPE)) {
+			if ((current = section.getInt("Y")) > max) {
+				max = current;
+			}
+		}
+		return max;
+	}
 }

--- a/src/main/java/net/querz/mcaselector/version/anvil118/Anvil118ChunkFilter.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil118/Anvil118ChunkFilter.java
@@ -292,16 +292,18 @@ public class Anvil118ChunkFilter extends Anvil117ChunkFilter {
 			}
 			pos = pos.chunkToBlock();
 
+			int yMax = Helper.findHighestSection(sections, -4);
+
 			// handle the special case when someone wants to replace air with something else
 			if (replace.containsKey("minecraft:air")) {
 				Map<Integer, CompoundTag> sectionMap = new HashMap<>();
-				List<Integer> heights = new ArrayList<>(26);
+				List<Integer> heights = new ArrayList<>(yMax + 5);
 				for (CompoundTag section : sections.iterateType(CompoundTag.TYPE)) {
 					sectionMap.put(section.getInt("Y"), section);
 					heights.add(section.getInt("Y"));
 				}
 
-				for (int y = -4; y < 20; y++) {
+				for (int y = -4; y <= yMax; y++) {
 					if (!sectionMap.containsKey(y)) {
 						sectionMap.put(y, completeSection(new CompoundTag(), y));
 						heights.add(y);
@@ -339,7 +341,7 @@ public class Anvil118ChunkFilter extends Anvil117ChunkFilter {
 				}
 
 				int y = Helper.numberFromCompound(section, "Y", -5).intValue();
-				if (y < -4 || y > 19) {
+				if (y < -4 || y > yMax) {
 					continue;
 				}
 

--- a/src/main/java/net/querz/mcaselector/version/anvil118/Anvil118ChunkRelocator.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil118/Anvil118ChunkRelocator.java
@@ -69,8 +69,9 @@ public class Anvil118ChunkRelocator implements ChunkRelocator {
 		ListTag sections = LegacyHelper.getSections(root, dataVersion);
 		if (sections != null) {
 			ListTag newSections = new ListTag();
+			int yMax = Helper.findHighestSection(sections, -4);
 			for (CompoundTag section : sections.iterateType(CompoundTag.TYPE)) {
-				if (applyOffsetToSection(section, offset.blockToSection(), -4, 19)) {
+				if (applyOffsetToSection(section, offset.blockToSection(), -4, yMax)) {
 					newSections.add(section);
 				}
 			}

--- a/src/main/java/net/querz/mcaselector/version/anvil118/Anvil118ChunkRenderer.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil118/Anvil118ChunkRenderer.java
@@ -25,16 +25,18 @@ public class Anvil118ChunkRenderer implements ChunkRenderer {
 
 		int absHeight = height + 64;
 
-		ListTag[] palettes = new ListTag[24];
-		long[][] blockStatesArray = new long[24][];
-		ListTag[] biomePalettes = new ListTag[24];
-		long[][] biomesArray = new long[24][];
+		int yMax = 1 + (height >> 4);
+		int sMax = yMax + 4;
+		ListTag[] palettes = new ListTag[sMax];
+		long[][] blockStatesArray = new long[sMax][];
+		ListTag[] biomePalettes = new ListTag[sMax];
+		long[][] biomesArray = new long[sMax][];
 		for (CompoundTag s : sections.iterateType(CompoundTag.TYPE)) {
 			ListTag p = LegacyHelper.getPalette(s, dataVersion);
 			long[] b = LegacyHelper.getBlockStates(s, dataVersion);
 
 			int y = Helper.numberFromCompound(s, "Y", -5).intValue();
-			if (y >= -4 && y < 20 && p != null) {
+			if (y >= -4 && y < yMax && p != null) {
 				palettes[y + 4] = p;
 				blockStatesArray[y + 4] = b;
 
@@ -53,7 +55,7 @@ public class Anvil118ChunkRenderer implements ChunkRenderer {
 
 				//loop over sections
 				boolean waterDepth = false;
-				for (int i = palettes.length - (24 - (absHeight >> 4)); i >= 0; i--) {
+				for (int i = palettes.length - (sMax - (absHeight >> 4)); i >= 0; i--) {
 					ListTag palette = palettes[i];
 					if (palette == null) {
 						continue;
@@ -216,16 +218,18 @@ public class Anvil118ChunkRenderer implements ChunkRenderer {
 
 		int absHeight = height + 64;
 
-		ListTag[] palettes = new ListTag[24];
-		long[][] blockStatesArray = new long[24][];
-		ListTag[] biomePalettes = new ListTag[24];
-		long[][] biomesArray = new long[24][];
+		int yMax = 1 + (height >> 4);
+		int sMax = yMax + 4;
+		ListTag[] palettes = new ListTag[sMax];
+		long[][] blockStatesArray = new long[sMax][];
+		ListTag[] biomePalettes = new ListTag[sMax];
+		long[][] biomesArray = new long[sMax][];
 		for (CompoundTag s : sections.iterateType(CompoundTag.TYPE)) {
 			ListTag p = LegacyHelper.getPalette(s, dataVersion);
 			long[] b = LegacyHelper.getBlockStates(s, dataVersion);
 
 			int y = Helper.numberFromCompound(s, "Y", -5).intValue();
-			if (y >= -4 && y < 20 && p != null) {
+			if (y >= -4 && y < yMax && p != null) {
 				palettes[y + 4] = p;
 				blockStatesArray[y + 4] = b;
 
@@ -246,7 +250,7 @@ public class Anvil118ChunkRenderer implements ChunkRenderer {
 				boolean doneSkipping = false;
 
 				// loop over sections
-				for (int i = palettes.length - (24 - (absHeight >> 4)); i >= 0; i--) {
+				for (int i = palettes.length - (sMax - (absHeight >> 4)); i >= 0; i--) {
 					ListTag palette = palettes[i];
 					if (palette == null) {
 						continue;

--- a/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkFilter.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkFilter.java
@@ -195,16 +195,18 @@ public class Anvil119ChunkFilter extends Anvil117ChunkFilter {
 		}
 		pos = pos.chunkToBlock();
 
+		int yMax = Helper.findHighestSection(sections, -4);
+
 		// handle the special case when someone wants to replace air with something else
 		if (replace.containsKey("minecraft:air")) {
 			Map<Integer, CompoundTag> sectionMap = new HashMap<>();
-			List<Integer> heights = new ArrayList<>(26);
+			List<Integer> heights = new ArrayList<>(yMax + 5);
 			for (CompoundTag section : sections.iterateType(CompoundTag.TYPE)) {
 				sectionMap.put(section.getInt("Y"), section);
 				heights.add(section.getInt("Y"));
 			}
 
-			for (int y = -4; y < 20; y++) {
+			for (int y = -4; y <= yMax; y++) {
 				if (!sectionMap.containsKey(y)) {
 					sectionMap.put(y, completeSection(new CompoundTag(), y));
 					heights.add(y);
@@ -242,7 +244,7 @@ public class Anvil119ChunkFilter extends Anvil117ChunkFilter {
 			}
 
 			int y = Helper.numberFromCompound(section, "Y", -5).intValue();
-			if (y < -4 || y > 19) {
+			if (y < -4 || y > yMax) {
 				continue;
 			}
 

--- a/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkRelocator.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkRelocator.java
@@ -47,8 +47,9 @@ public class Anvil119ChunkRelocator implements ChunkRelocator {
 		ListTag sections = Helper.tagFromCompound(root, "sections");
 		if (sections != null) {
 			ListTag newSections = new ListTag();
+			int yMax = Helper.findHighestSection(sections, -4);
 			for (CompoundTag section : sections.iterateType(CompoundTag.TYPE)) {
-				if (applyOffsetToSection(section, offset.blockToSection(), -4, 19)) {
+				if (applyOffsetToSection(section, offset.blockToSection(), -4, yMax)) {
 					newSections.add(section);
 				}
 			}

--- a/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkRenderer.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkRenderer.java
@@ -20,20 +20,21 @@ public class Anvil119ChunkRenderer implements ChunkRenderer {
 
 		int absHeight = height + 64;
 
-		ListTag[] palettes = new ListTag[24];
-		long[][] blockStatesArray = new long[24][];
-		ListTag[] biomePalettes = new ListTag[24];
-		long[][] biomesArray = new long[24][];
+		int yMax = 1 + (height >> 4);
+		int sMax = yMax + 4;
+		ListTag[] palettes = new ListTag[sMax];
+		long[][] blockStatesArray = new long[sMax][];
+		ListTag[] biomePalettes = new ListTag[sMax];
+		long[][] biomesArray = new long[sMax][];
 		sections.forEach(s -> {
 			ListTag p = Helper.tagFromCompound(Helper.tagFromCompound(s, "block_states"), "palette");
 
 			int y = Helper.numberFromCompound(s, "Y", -5).intValue();
-			if (y >= -4 && y < 20 && p != null) {
+			if (y >= -4 && y < yMax && p != null) {
 				palettes[y + 4] = p;
 				blockStatesArray[y + 4] = Helper.longArrayFromCompound(Helper.tagFromCompound(s, "block_states"), "data");;
 				biomePalettes[y + 4] = Helper.tagFromCompound(Helper.tagFromCompound(s, "biomes"), "palette");
 				biomesArray[y + 4] = Helper.longArrayFromCompound(Helper.tagFromCompound(s, "biomes"), "data");
-
 			}
 		});
 
@@ -43,7 +44,7 @@ public class Anvil119ChunkRenderer implements ChunkRenderer {
 
 				//loop over sections
 				boolean waterDepth = false;
-				for (int i = palettes.length - (24 - (absHeight >> 4)); i >= 0; i--) {
+				for (int i = palettes.length - (sMax - (absHeight >> 4)); i >= 0; i--) {
 					ListTag palette = palettes[i];
 					if (palette == null) {
 						continue;

--- a/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkRenderer.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil119/Anvil119ChunkRenderer.java
@@ -174,15 +174,17 @@ public class Anvil119ChunkRenderer implements ChunkRenderer {
 
 		int absHeight = height + 64;
 
-		ListTag[] palettes = new ListTag[24];
-		long[][] blockStatesArray = new long[24][];
-		ListTag[] biomePalettes = new ListTag[24];
-		long[][] biomesArray = new long[24][];
+		int yMax = 1 + (height >> 4);
+		int sMax = yMax + 4;
+		ListTag[] palettes = new ListTag[sMax];
+		long[][] blockStatesArray = new long[sMax][];
+		ListTag[] biomePalettes = new ListTag[sMax];
+		long[][] biomesArray = new long[sMax][];
 		sections.forEach(s -> {
 			ListTag p = Helper.tagFromCompound(Helper.tagFromCompound(s, "block_states"), "palette");
 
 			int y = Helper.numberFromCompound(s, "Y", -5).intValue();
-			if (y >= -4 && y < 20 && p != null) {
+			if (y >= -4 && y < yMax && p != null) {
 				palettes[y + 4] = p;
 				blockStatesArray[y + 4] = Helper.longArrayFromCompound(Helper.tagFromCompound(s, "block_states"), "data");
 				biomePalettes[y + 4] = Helper.tagFromCompound(Helper.tagFromCompound(s, "biomes"), "palette");
@@ -198,7 +200,7 @@ public class Anvil119ChunkRenderer implements ChunkRenderer {
 				boolean doneSkipping = false;
 
 				// loop over sections
-				for (int i = palettes.length - (24 - (absHeight >> 4)); i >= 0; i--) {
+				for (int i = palettes.length - (sMax - (absHeight >> 4)); i >= 0; i--) {
 					ListTag palette = palettes[i];
 					if (palette == null) {
 						continue;


### PR DESCRIPTION
update the height slider to support values above 319 for 1.18+ worlds with datapacks that increase the world height.

the slider still shows the default range of -64 to 319, but the input field to its right now accepts values up to 2047.

the slider in the settings dialog has been changed as well.

all places where the maximum height was hard coded now try to determine the maximum height dynamically based on the maximum `Y` value in all sections.