### PR TITLE
Fixing import and export mode in CLI

### DIFF
--- a/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
@@ -107,6 +107,10 @@ public final class ParamExecutor {
 			.desc("Whether to force NBT tags during NBT change")
 			.build());
 		options.addOption(Option.builder()
+			.longOpt("sections")
+			.desc("One or a range of section indices to import into the target world during chunk import")
+			.build());
+		options.addOption(Option.builder()
 			.longOpt("render-height")
 			.desc("The highest Y level to render in image mode")
 			.hasArg()

--- a/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
@@ -109,6 +109,7 @@ public final class ParamExecutor {
 		options.addOption(Option.builder()
 			.longOpt("sections")
 			.desc("One or a range of section indices to import into the target world during chunk import")
+			.hasArg()
 			.build());
 		options.addOption(Option.builder()
 			.longOpt("render-height")
@@ -344,7 +345,7 @@ public final class ParamExecutor {
 	private void printHelp() {
 		String[] helpOrder = new String[]{
 			"help", "version", "mode", "output", "query", "selection", "source-selection", "radius", "x-offset",
-			"y-offset", "z-offset", "overwrite", "force", "render-height", "render-caves", "render-layer-only",
+			"y-offset", "z-offset", "overwrite", "force", "sections", "render-height", "render-caves", "render-layer-only",
 			"render-shade", "render-water-shade", "overlay-type", "overlay-min-value", "overlay-max-value",
 			"overlay-data", "overlay-min-hue", "overlay-max-hue", "zoom-level", "world", "region", "poi", "entities",
 			"source-world", "source-region", "source-poi", "source-entities", "output-world", "output-region",
@@ -517,7 +518,7 @@ public final class ParamExecutor {
 			poi = parseDirAndCreate(poiName);
 		} else {
 			poi = new File(world, "poi");
-			if (!region.mkdirs()) {
+			if (!poi.mkdirs()) {
 				throw new ParseException(String.format("failed to create poi directory %s", poi));
 			}
 		}

--- a/src/main/java/net/querz/mcaselector/io/job/ChunkImporter.java
+++ b/src/main/java/net/querz/mcaselector/io/job/ChunkImporter.java
@@ -337,7 +337,7 @@ public final class ChunkImporter {
 
 				ChunkSet targetChunks = null;
 				if (targetSelection != null) {
-					targetChunks = sourceSelection.getSelectedChunks(target);
+					targetChunks = targetSelection.getSelectedChunks(target);
 				}
 
 				for (Map.Entry<Point2i, byte[]> sourceData : sourceDataMappingRegion.entrySet()) {


### PR DESCRIPTION
Previously the export mode would always throw an error when creating the output directories because of a simple typo.

Also the import mode would not parse the "sections" argument which led to mca always importing the whole chunk instead of just the specified sections.