### PR TITLE
[cli] set write threads using write threads value

### DIFF
--- a/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
@@ -394,7 +394,7 @@ public final class ParamExecutor {
 		ConfigProvider.GLOBAL = new GlobalConfig();
 		ConfigProvider.GLOBAL.setDebug(line.hasOption("debug"));
 		ConfigProvider.GLOBAL.setProcessThreads(parseInt("process-threads", GlobalConfig.DEFAULT_PROCESS_THREADS, 1, 128));
-		ConfigProvider.GLOBAL.setProcessThreads(parseInt("write-threads", GlobalConfig.DEFAULT_WRITE_THREADS, 1, 128));
+		ConfigProvider.GLOBAL.setWriteThreads(parseInt("write-threads", GlobalConfig.DEFAULT_WRITE_THREADS, 1, 128));
 	}
 
 	private void printError(String msg, Object... params) {


### PR DESCRIPTION
Fixes a copy-paste bug that was causing process threads to be set to the value of the write threads command line argument, which typically defaults to a very low number. This causes command line operations to be unnecessarily slow even with many process threads specified on command line.