### PR TITLE
Fix #486 by checking for null minecraft:lodestone_target

### DIFF
--- a/src/main/java/net/querz/mcaselector/version/anvil120/Anvil120ChunkRelocator.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil120/Anvil120ChunkRelocator.java
@@ -197,9 +197,11 @@ public class Anvil120ChunkRelocator implements ChunkRelocator {
 			switch (id) {
 			case "minecraft:compass":
 				CompoundTag lodestoneTarget = Helper.tagFromCompound(components, "minecraft:lodestone_target");
-				IntArrayTag pos = lodestoneTarget.getIntArrayTag("pos");
-				if (pos != null) {
-					Helper.applyOffsetToIntArrayPos(pos, offset);
+				if (lodestoneTarget != null) {
+					IntArrayTag pos = lodestoneTarget.getIntArrayTag("pos");
+					if (pos != null) {
+						Helper.applyOffsetToIntArrayPos(pos, offset);
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
This pull request fixes #486 by adding an additional null check to the code that handles relocating Compasses' "minecraft:lodestone_target" NBT/Compound values in the Anvil120ChunkRelocator.