### PR TITLE
Fixed Exception when relocating EnderIO BlockEntity

### DIFF
--- a/src/main/java/net/querz/mcaselector/version/anvil120/Anvil120ChunkRelocator.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil120/Anvil120ChunkRelocator.java
@@ -6,6 +6,8 @@ import net.querz.mcaselector.version.Helper;
 import net.querz.mcaselector.version.anvil118.Anvil118EntityRelocator;
 import net.querz.nbt.*;
 import java.util.Map;
+import java.util.logging.LogManager;
+
 import static net.querz.mcaselector.validation.ValidationHelper.silent;
 import static net.querz.mcaselector.version.anvil118.Anvil118EntityRelocator.applyOffsetToEntity;
 
@@ -175,10 +177,14 @@ public class Anvil120ChunkRelocator implements ChunkRelocator {
 				}
 		}
 
-		ListTag items = Helper.tagFromCompound(tileEntity, "Items");
-		if (items != null) {
-			items.forEach(i -> applyOffsetToItem((CompoundTag) i, offset, dataVersion));
-		}
+        Tag itemsTag = Helper.tagFromCompound(tileEntity, "Items");
+        if (itemsTag != null) {
+            if(itemsTag instanceof CompoundTag items){
+                items.forEach(i -> applyOffsetToItem((CompoundTag) i, offset, dataVersion));
+            }else{
+                LogManager.getLogManager().getLogger(Anvil120ChunkRelocator.class.getName()).warning("Skipping "+ ((StringTag) tileEntity.get("id")).getValue());
+            }
+        }
 	}
 
 	static void applyOffsetToItem(CompoundTag item, Point3i offset, int dataVersion) {
@@ -231,9 +237,13 @@ public class Anvil120ChunkRelocator implements ChunkRelocator {
 
 			// recursively update all items in child containers
 			CompoundTag blockEntityTag = Helper.tagFromCompound(tag, "BlockEntityTag");
-			ListTag items = Helper.tagFromCompound(blockEntityTag, "Items");
-			if (items != null) {
-				items.forEach(i -> applyOffsetToItem((CompoundTag) i, offset, dataVersion));
+			Tag itemsTag = Helper.tagFromCompound(blockEntityTag, "Items");
+			if (itemsTag != null) {
+                if(itemsTag instanceof ListTag items){
+                    items.forEach(i -> applyOffsetToItem((CompoundTag) i, offset, dataVersion));
+                }else{
+                    LogManager.getLogManager().getLogger(Anvil120ChunkRelocator.class.getName()).warning("Skipping "+ ((StringTag) item.get("id")).getValue());
+                }
 			}
 		}
 	}


### PR DESCRIPTION
The chunk relocation process fails when a chunk contains any EnderIO BlockEntity due to the way these entities save their content. The format used by EnderIO BlockEntities is currently not handled by the relocator. However, since these BlockEntities do not contain any data that requires relocation (as far as I know), it should be safe to skip over them during the relocation process.