### PR TITLE
Fix #508 by update `lodestone_target` to `lodestone_tracker`

### DIFF
--- a/src/main/java/net/querz/mcaselector/version/anvil120/Anvil120ChunkRelocator.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil120/Anvil120ChunkRelocator.java
@@ -196,9 +196,10 @@ public class Anvil120ChunkRelocator implements ChunkRelocator {
 			String id = Helper.stringFromCompound(item, "id", "");
 			switch (id) {
 			case "minecraft:compass":
-				CompoundTag lodestoneTarget = Helper.tagFromCompound(components, "minecraft:lodestone_target");
-				if (lodestoneTarget != null) {
-					IntArrayTag pos = lodestoneTarget.getIntArrayTag("pos");
+				CompoundTag lodestoneTracker = Helper.tagFromCompound(components, "minecraft:lodestone_tracker");
+				if (lodestoneTracker != null) {
+					CompoundTag target = Helper.tagFromCompound(lodestoneTracker, "target");
+					IntArrayTag pos = target.getIntArrayTag("pos");
 					if (pos != null) {
 						Helper.applyOffsetToIntArrayPos(pos, offset);
 					}

--- a/src/main/java/net/querz/mcaselector/version/anvil121/Anvil121ChunkRelocator.java
+++ b/src/main/java/net/querz/mcaselector/version/anvil121/Anvil121ChunkRelocator.java
@@ -189,10 +189,13 @@ public class Anvil121ChunkRelocator implements ChunkRelocator {
 		String id = Helper.stringFromCompound(item, "id", "");
 		switch (id) {
 		case "minecraft:compass":
-			CompoundTag lodestoneTarget = Helper.tagFromCompound(components, "minecraft:lodestone_target");
-			IntArrayTag pos = lodestoneTarget.getIntArrayTag("pos");
-			if (pos != null) {
-				Helper.applyOffsetToIntArrayPos(pos, offset);
+			CompoundTag lodestoneTracker = Helper.tagFromCompound(components, "minecraft:lodestone_tracker");
+			if (lodestoneTracker != null) {
+				CompoundTag target = Helper.tagFromCompound(lodestoneTracker, "target");
+				IntArrayTag pos = target.getIntArrayTag("pos");
+				if (pos != null) {
+					Helper.applyOffsetToIntArrayPos(pos, offset);
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Component `lodestone_target` was renamed as `lodestone_tracker` and the structure is changed since 24w10a. This PR updates it in the code and fixes #508.