### PR TITLE
Reverted a corruption in older versions caused by the version handler…

### DIFF
--- a/src/main/java/net/querz/mcaselector/version/java_1_13/ChunkRenderer_17w47a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_13/ChunkRenderer_17w47a.java
@@ -111,7 +111,7 @@ public class ChunkRenderer_17w47a implements ChunkRenderer<CompoundTag, Integer>
 								waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome); // color of block at bottom of water
 							}
 						} else {
-							waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome);
+							pixelBuffer[pixelIndex] = colorMapping.getRGB(blockData, biome);
 						}
 						terrainHeights[pixelIndex] = (short) (sectionHeight[i] + cy);
 						continue zLoop;

--- a/src/main/java/net/querz/mcaselector/version/java_1_13/ChunkRenderer_18w06a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_13/ChunkRenderer_18w06a.java
@@ -116,7 +116,7 @@ public class ChunkRenderer_18w06a implements ChunkRenderer<CompoundTag, Integer>
 								waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome); // color of block at bottom of water
 							}
 						} else {
-							waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome);
+							pixelBuffer[pixelIndex] = colorMapping.getRGB(blockData, biome);
 						}
 						terrainHeights[pixelIndex] = (short) (sectionHeight[i] + cy);
 						continue zLoop;

--- a/src/main/java/net/querz/mcaselector/version/java_1_15/ChunkRenderer_19w36a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_15/ChunkRenderer_19w36a.java
@@ -117,7 +117,7 @@ public class ChunkRenderer_19w36a implements ChunkRenderer<CompoundTag, Integer>
 								waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome); // color of block at bottom of water
 							}
 						} else {
-							waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome);
+							pixelBuffer[pixelIndex] = colorMapping.getRGB(blockData, biome);
 						}
 						terrainHeights[pixelIndex] = (short) (sectionHeight[i] + cy);
 						continue zLoop;

--- a/src/main/java/net/querz/mcaselector/version/java_1_16/ChunkRenderer_20w17a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_16/ChunkRenderer_20w17a.java
@@ -120,7 +120,7 @@ public class ChunkRenderer_20w17a implements ChunkRenderer<CompoundTag, Integer>
 								waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome); // color of block at bottom of water
 							}
 						} else {
-							waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome);
+							pixelBuffer[pixelIndex] = colorMapping.getRGB(blockData, biome);
 						}
 						terrainHeights[pixelIndex] = (short) (sectionHeight[i] + cy);
 						continue zLoop;

--- a/src/main/java/net/querz/mcaselector/version/java_1_17/ChunkRenderer_21w06a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_17/ChunkRenderer_21w06a.java
@@ -121,7 +121,7 @@ public class ChunkRenderer_21w06a implements ChunkRenderer<CompoundTag, Integer>
 								waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome); // color of block at bottom of water
 							}
 						} else {
-							waterPixels[pixelIndex] = colorMapping.getRGB(blockData, biome);
+							pixelBuffer[pixelIndex] = colorMapping.getRGB(blockData, biome);
 						}
 						terrainHeights[pixelIndex] = (short) (sectionHeight[i] + cy);
 						continue zLoop;

--- a/src/main/java/net/querz/mcaselector/version/java_1_9/ChunkRenderer_15w32a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_9/ChunkRenderer_15w32a.java
@@ -100,7 +100,7 @@ public class ChunkRenderer_15w32a implements ChunkRenderer<Integer, Integer> {
 								waterPixels[pixelIndex] = colorMapping.getRGB((block << 4) + data, biome);
 							}
 						} else {
-							waterPixels[pixelIndex] = colorMapping.getRGB((block << 4) + data, biome);
+							pixelBuffer[pixelIndex] = colorMapping.getRGB((block << 4) + data, biome);
 						}
 						terrainHeights[pixelIndex] = (short) (sectionHeight[i] + cy);
 						continue zLoop;


### PR DESCRIPTION
In the renderer in the versions prior to 1.18 the `pixelBuffer` was changed to `waterPixels` for the cases other that water somehow
It only breaks tho when one of the new shade toggles is off
Still when reverted back to `pixelBuffer` everything seems to work(I havent look to much into it)