### PR TITLE
add gradle task to generate flatpak sources for offline builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 	id 'com.gradleup.shadow' version '9.2.2'
 	id 'com.github.ben-manes.versions' version '0.52.0'
 	id 'org.beryx.runtime' version '2.0.1'
-	id "io.github.jwharm.flatpak-gradle-generator" version "1.5.0"
+	id "io.github.jwharm.flatpak-gradle-generator" version "1.6.0"
 }
 
 group = 'net.querz'

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 	id 'com.gradleup.shadow' version '9.2.2'
 	id 'com.github.ben-manes.versions' version '0.52.0'
 	id 'org.beryx.runtime' version '2.0.1'
+	id "io.github.jwharm.flatpak-gradle-generator" version "1.5.0"
 }
 
 group = 'net.querz'
@@ -36,6 +37,7 @@ repositories {
 	mavenCentral()
 	maven { url = 'https://jitpack.io/' }
 	maven { url = 'https://plugins.gradle.org/m2/' }
+	maven { url = "./offline-repository" }
 }
 
 dependencies {
@@ -81,6 +83,11 @@ tasks.register('minifyCss') {
 tasks.register('generator', JavaExec) {
 	mainClass = 'net.querz.mcaselector.version.mapping.generator.Main'
 	classpath = sourceSets.main.runtimeClasspath
+}
+
+tasks.flatpakGradleGenerator {
+  outputFile = file("flatpak-sources.json")
+  downloadDirectory = "./offline-repository"
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 	id 'com.gradleup.shadow' version '9.2.2'
 	id 'com.github.ben-manes.versions' version '0.52.0'
 	id 'org.beryx.runtime' version '2.0.1'
-	id "io.github.jwharm.flatpak-gradle-generator" version "1.5.0"
+	id "io.github.jwharm.flatpak-gradle-generator" version "1.8.0"
 }
 
 group = 'net.querz'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,14 @@
+pluginManagement {
+  repositories {
+  	mavenCentral()
+  	maven {
+  		url 'https://jitpack.io/'
+  	}
+  	maven {
+  		url 'https://plugins.gradle.org/m2/'
+  	}
+  	maven { url "./offline-repository" }
+  }
+}
+
 rootProject.name = 'mcaselector'


### PR DESCRIPTION
Preparing for: #126, #462

To publish a Flatpak Linux package on Flathub, we need to build the application without network connectivity (offline build).

The `flatpakGradleGenerator` task will generate a list of sources for dependencies, so they can be prefetched and used during the build as an offline repository.

See: https://github.com/jwharm/flatpak-gradle-generator

---

I understand if this wasn't accepted here in upstream. I could just use a patch to generate the sources for packaging, but it would be cleaner to have it here and to keeps maintenance minimal.

It is useful for any type of offline builds, `flatpak-sources.json` is easy to parse and do anything with, not a special and complicated format.