### PR TITLE
Add --biomes flag for biome-only chunk import

### DIFF
--- a/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
+++ b/src/main/java/net/querz/mcaselector/cli/ParamExecutor.java
@@ -130,6 +130,10 @@ public final class ParamExecutor {
 			.hasArg()
 			.get());
 		options.addOption(Option.builder()
+			.longOpt("biomes")
+			.desc("Import only biome data, not blocks or entities")
+			.get());
+		options.addOption(Option.builder()
 			.longOpt("render-height")
 			.desc("The highest Y level to render in image mode")
 			.hasArg()
@@ -685,6 +689,11 @@ public final class ParamExecutor {
 	}
 
 	private List<Range> parseSections(boolean mandatory) throws ParseException {
+		// If --biomes is set, return empty list (special flag for biomes-only import)
+		if (line.hasOption("biomes")) {
+			return new ArrayList<>();
+		}
+
 		if (!line.hasOption("sections")) {
 			if (mandatory) {
 				throw new ParseException("missing mandatory sections parameter");

--- a/src/main/java/net/querz/mcaselector/version/ChunkFilter.java
+++ b/src/main/java/net/querz/mcaselector/version/ChunkFilter.java
@@ -106,6 +106,42 @@ public interface ChunkFilter {
 
 		CompoundTag newEmptyChunk(Point2i absoluteLocation, int dataVersion);
 
+		// Biomes-only merge for modern Minecraft (1.18+)
+		default void mergeBiomesOnly(CompoundTag source, CompoundTag destination) {
+			// In Minecraft 1.18+, biomes are stored in sections
+			if (source.containsKey("sections") && destination.containsKey("sections")) {
+				ListTag sourceSections = source.getListTag("sections");
+				ListTag destSections = destination.getListTag("sections");
+
+				if (sourceSections != null && destSections != null) {
+					// Create map of Y -> Section for fast lookup
+					java.util.Map<Integer, CompoundTag> destSectionMap = new java.util.HashMap<>();
+					for (Tag tag : destSections) {
+						if (tag instanceof CompoundTag section) {
+							int y = section.getInt("Y");
+							destSectionMap.put(y, section);
+						}
+					}
+
+					// Copy biomes from source sections
+					for (Tag tag : sourceSections) {
+						if (tag instanceof CompoundTag sourceSection) {
+							int y = sourceSection.getInt("Y");
+							CompoundTag destSection = destSectionMap.get(y);
+
+							if (destSection != null && sourceSection.containsKey("biomes")) {
+								// Copy biome palette
+								Tag biomeData = sourceSection.get("biomes");
+								if (biomeData != null) {
+									destSection.put("biomes", biomeData.copy());
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
 		default ListTag mergeLists(ListTag source, ListTag destination, List<Range> ranges, Function<Tag, Integer> ySupplier, int yOffset) {
 			ListTag result = new ListTag();
 			for (Tag dest : destination) {

--- a/src/main/java/net/querz/mcaselector/version/java_1_18/ChunkFilter_21w43a.java
+++ b/src/main/java/net/querz/mcaselector/version/java_1_18/ChunkFilter_21w43a.java
@@ -633,6 +633,12 @@ public class ChunkFilter_21w43a {
 
 		@Override
 		public void mergeChunks(CompoundTag source, CompoundTag destination, List<Range> ranges, int yOffset) {
+			// Empty ranges list = biomes-only mode
+			if (ranges != null && ranges.isEmpty()) {
+				mergeBiomesOnly(source, destination);
+				return;
+			}
+
 			mergeCompoundTagLists(source, destination, ranges, yOffset, "sections", c -> ((CompoundTag) c).getInt("Y"));
 			mergeCompoundTagLists(source, destination, ranges, yOffset, "block_entities", c -> ((CompoundTag) c).getInt("y") >> 4);
 			mergeCompoundTagLists(source, destination, ranges, yOffset, "block_ticks", c -> ((CompoundTag) c).getInt("y") >> 4);


### PR DESCRIPTION
Introduces a new --biomes command-line flag that allows importing only biome data during chunk merge operations, without importing blocks or entities.

This is useful for transferring biomes between worlds while preserving the existing terrain and structures.

Implementation:
- Added --biomes CLI option in ParamExecutor
- Implemented mergeBiomesOnly() method in ChunkFilter interface
- Modified mergeChunks() to detect and handle biomes-only mode

The biomes-only mode is triggered by passing an empty ranges list, which signals the merge operation to only copy biome palette data from source sections to destination sections.